### PR TITLE
Fix ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ jobs:
 
   - stage: Deploy
     if: tag IS present
-    before_deploy: yarn tsc --project tsconfig.prod.json
     deploy:
       provider: npm
       email: alyssondlopes@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
     script: yarn lint && yarn tsc --noEmit
 
   - stage: Test on Release PR
-    if: branch =~ /^release\// OR branch =~ /^hotfix\//  AND (type = pull_request)
+    if: (branch =~ /^release\// OR branch =~ /^hotfix\//) AND (type = pull_request)
     install:
     - yarn install
     name:  Test on Release PR

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,21 +16,21 @@ jobs:
     install:
     - yarn install
     name:  Test on Release PR
-    script: yarn test --coverage --changedSince=main && yarn codecov -t $CODECOV_TOKEN
+    script: yarn jest --coverage --changedSince=main && yarn codecov -t $CODECOV_TOKEN
 
   - stage: Test on Pull Request
     if: (NOT branch =~ /^release\\//) AND (NOT branch =~ /^hotfix\\//) AND (type = pull_request)
     install:
     - yarn install
     name: Test on Pull Request
-    script: yarn test --coverage --changedSince=develop && yarn codecov -t $CODECOV_TOKEN
+    script: yarn jest --coverage --changedSince=develop && yarn codecov -t $CODECOV_TOKEN
 
   - stage: Coverage
     if: branch IN (develop, main) AND (NOT type = pull_request)
     install:
     - yarn install
     name: CI on develop branch
-    script: yarn test --coverage && yarn codecov -t $CODECOV_TOKEN
+    script: yarn jest --coverage && yarn codecov -t $CODECOV_TOKEN
 
   - stage: Deploy
     if: tag IS present

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react": "^16.13.1",
     "react-native": "^0.63.3",
     "react-test-renderer": "^17.0.1",
+    "rimraf": "^3.0.2",
     "standard-changelog": "^2.0.27",
     "tscpaths": "^0.0.9",
     "typescript": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "install:ios": "yarn && npx pod-install ios",
     "install:android": "yarn",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "test": "jest .",
     "lint": "eslint ./src --ext .ts,.tsx",
     "prepublishOnly": "yarn clean && tsc --project tsconfig.prod.json && tscpaths -p tsconfig.prod.json -s ./src -o ./dist",


### PR DESCRIPTION
# What

Our builds were not able to deploy new versions to npm. Besides that, PRs generated two different build unnecessarily: one for the pr and other for the push.

This PR fixes theses behaviors.