### PR TITLE
ci: add before_deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ jobs:
 
   - stage: Deploy to NPM
     if: tag IS present
-    install:
-    - yarn install
+    before_deploy: yarn install
     deploy:
       provider: npm
       email: alyssondlopes@gmail.com


### PR DESCRIPTION
# What

Add `before_deploy` script to run `yarn install`

# Why

We need to install dependencies on CI before deploying because we use `rimraf` lib on deploy process.
Without installing it, the deploy script will fail.
