### PR TITLE
fix(TextInput): update state when value changes

### DIFF
--- a/src/components/Inputs/InputLabel.tsx
+++ b/src/components/Inputs/InputLabel.tsx
@@ -46,7 +46,7 @@ function InputLabel({
         toValue: getLabelPosition({ expandLabel, large }),
       }).start();
     }
-  }, [hasFocus]);
+  }, [hasFocus, isEmpty]);
 
   return (
     <Animated.View

--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { TextInput as RNTextInput, Pressable, StyleSheet, View } from 'react-native';
 
 import { getInputBackgroundColor, getInputBorderColor } from './utils';
@@ -54,6 +54,12 @@ function TextInput({
     fontSize: baseSize,
     paddingRight: hasError || isValidated ? 56 : baseSize,
   };
+
+  useEffect(() => {
+    if (!Boolean(props.value) !== isEmpty) {
+      setIsEmpty(!Boolean(props.value));
+    }
+  }, [props.value]);
 
   function handleInputPress() {
     inputRef.current?.focus();

--- a/src/components/Inputs/__tests__/TextInput.test.tsx
+++ b/src/components/Inputs/__tests__/TextInput.test.tsx
@@ -109,6 +109,64 @@ describe('TextInput', () => {
     );
   });
 
+  it('renders correctly on blur state and the value changes', () => {
+    const { getByTestId, rerender } = render(<TextInput {...props} value="" />);
+
+    act(() => {
+      getByTestId('TextInput.Input').props.onBlur();
+    });
+
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+
+    expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
+      expect.objectContaining({
+        borderWidth: 1,
+        borderRadius: 8,
+      })
+    );
+    expect(getByTestId('TextInput.Container').props.style[1]).toEqual(
+      expect.objectContaining({ backgroundColor: colors.space100, borderColor: colors.moon900 })
+    );
+
+    expect(getByTestId('TextInput.Input').props.style[0]).toEqual(
+      expect.objectContaining({
+        fontFamily: 'Lato-Regular',
+        paddingBottom: 8,
+        paddingTop: 28,
+      })
+    );
+    expect(getByTestId('TextInput.Input').props.style[1]).toEqual(
+      expect.objectContaining({ paddingLeft: 16, fontSize: 16, paddingRight: 16 })
+    );
+    expect(getByTestId('TextInput.Input').props.value).toEqual('');
+
+    timeTravel(200);
+    expect(getByTestId('InputLabel').props.style).toEqual(
+      expect.objectContaining({
+        transform: [{ translateY: 16 }],
+        position: 'absolute',
+        overflow: 'hidden',
+        width: '95%',
+        left: 0,
+        top: 0,
+      })
+    );
+
+    rerender(<TextInput {...props} value="some value" />);
+    expect(getByTestId('TextInput.Input').props.value).toEqual('some value');
+    timeTravel(200);
+    expect(getByTestId('InputLabel').props.style).toEqual(
+      expect.objectContaining({
+        transform: [{ translateY: 6 }],
+        position: 'absolute',
+        overflow: 'hidden',
+        width: '95%',
+        left: 0,
+        top: 0,
+      })
+    );
+  });
+
   it('renders correctly on focus state', () => {
     const { getByTestId } = render(<TextInput {...props} />);
 


### PR DESCRIPTION
# What

Improves `TextInput` and `InputLabel` to update internal state when value passed by props changes.

# Why

The label wasn't animating to correct state when value passed by props changed.

# How

- **TextInput**: adding an `useEffect` to "listen" when this prop change and update internal state
- **InputLabel**: adding `isEmpty` prop to existing `useEffect`

