### PR TITLE
[AST-9] Fix link component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
     if: type = pull_request
     install:
     - yarn install
-    script: yarn jest --coverage --changedSince=main && yarn codecov -t $CODECOV_TOKEN
+    script: yarn jest --coverage && yarn codecov -t $CODECOV_TOKEN
 
   - stage: Run Tests & Upload Coverage Report
     if: NOT type = pull_request AND branch = main

--- a/src/components/Buttons/Link.tsx
+++ b/src/components/Buttons/Link.tsx
@@ -1,11 +1,11 @@
 import React, { ReactElement } from 'react';
-import { Pressable, PressableProps } from 'react-native';
-import { colors } from '@magnetis/astro-galaxy-tokens';
+import { TextProps } from 'react-native';
 
 import { isValidTextComponent } from './utils';
 
-interface LinkProps extends PressableProps {
+interface LinkProps extends TextProps {
   children: ReactElement;
+  /** Color to be used as background color of button. Defaults to `"uranus"`. */
   /** Link press callback */
   onPress: () => void;
 }
@@ -14,13 +14,13 @@ interface LinkProps extends PressableProps {
  * For inline links in paragraphs and informative texts. Regular links navigate to other pages or external content.
  */
 function Link({ children, onPress, ...props }: LinkProps) {
-  return (
-    <Pressable hitSlop={10} onPress={onPress} {...props}>
-      {isValidTextComponent(children)
-        ? React.cloneElement(children, { color: colors.uranus700, style: { textDecorationLine: 'underline' } })
-        : null}
-    </Pressable>
-  );
+  return isValidTextComponent(children)
+    ? React.cloneElement(children, {
+        ...props,
+        onPress,
+        style: { textDecorationLine: 'underline' },
+      })
+    : null;
 }
 
 export default Link;

--- a/src/components/Buttons/Link.tsx
+++ b/src/components/Buttons/Link.tsx
@@ -1,11 +1,13 @@
 import React, { ReactElement } from 'react';
 import { TextProps } from 'react-native';
 
-import { isValidTextComponent } from './utils';
+import type { ButtonColor } from './types';
+import { getButtonMainColor, isValidTextComponent } from './utils';
 
 interface LinkProps extends TextProps {
   children: ReactElement;
   /** Color to be used as background color of button. Defaults to `"uranus"`. */
+  color?: ButtonColor;
   /** Link press callback */
   onPress: () => void;
 }
@@ -13,10 +15,11 @@ interface LinkProps extends TextProps {
 /**
  * For inline links in paragraphs and informative texts. Regular links navigate to other pages or external content.
  */
-function Link({ children, onPress, ...props }: LinkProps) {
+function Link({ children, onPress, color = 'uranus', ...props }: LinkProps) {
   return isValidTextComponent(children)
     ? React.cloneElement(children, {
         ...props,
+        color: getButtonMainColor(color),
         onPress,
         style: { textDecorationLine: 'underline' },
       })

--- a/src/components/Buttons/__tests__/Link.test.tsx
+++ b/src/components/Buttons/__tests__/Link.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react-native';
 
 import Link from '../Link';
 import { PrimaryTextMedium } from '@components/Text';
+import { getButtonMainColor } from '../utils';
 
 const onPress = jest.fn();
 
@@ -22,6 +23,22 @@ describe('Link', () => {
     expect(getByText('this is a link').props.style).toEqual(
       expect.objectContaining({
         textDecorationLine: 'underline',
+        color: getButtonMainColor('uranus'),
+      })
+    );
+  });
+
+  it('renders correctly with mars color prop', () => {
+    const { getByText } = render(
+      <Link onPress={onPress} color="mars">
+        <PrimaryTextMedium>this is a link</PrimaryTextMedium>
+      </Link>
+    );
+
+    expect(getByText('this is a link').props.style).toEqual(
+      expect.objectContaining({
+        textDecorationLine: 'underline',
+        color: getButtonMainColor('mars'),
       })
     );
   });

--- a/src/components/Buttons/__tests__/Link.test.tsx
+++ b/src/components/Buttons/__tests__/Link.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Text } from 'react-native';
 import { render } from '@testing-library/react-native';
-import { colors } from '@magnetis/astro-galaxy-tokens';
 
 import Link from '../Link';
 import { PrimaryTextMedium } from '@components/Text';
@@ -23,7 +22,6 @@ describe('Link', () => {
     expect(getByText('this is a link').props.style).toEqual(
       expect.objectContaining({
         textDecorationLine: 'underline',
-        color: colors.uranus700,
       })
     );
   });


### PR DESCRIPTION
# What
- Fix link component

# Why
- The component was aligned vertically when nested inside another `Text` component

# How
- Removed `Pressable` wrapper

# Extra
Added color prop to component, basing on button color props (`'uranus' | 'earth' | 'venus' | 'mars'`)

# Sample
| With Pressable | Without Pressable |
| ------------- |-------------| 
| <img src="https://user-images.githubusercontent.com/13890272/104501565-a8daf080-55be-11eb-99e5-3a3882a26b08.png" height="80" width="250" /> | <img src="https://user-images.githubusercontent.com/13890272/104501567-a9738700-55be-11eb-97f5-0c843a4012ef.png" height="80" width="250" /> |

[CH54268](https://app.clubhouse.io/magnetis/story/54268/corrigir-alinhamento-vertical-de-links-aninhados-em-componentes-de-texto)
