### PR TITLE
Chore/fix clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "react": "^16.13.1",
     "react-native": "^0.63.3",
     "react-test-renderer": "^17.0.1",
-    "rimraf": "^3.0.2",
     "standard-changelog": "^2.0.27",
     "tscpaths": "^0.0.9",
     "typescript": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "scripts": {
     "install:ios": "yarn && npx pod-install ios",
     "install:android": "yarn",
-    "clean": "yarn rimraf ./dist",
     "test": "jest",
     "test:watch": "yarn test --watch --collect-coverage",
+    "clean": "rm -rf ./dist",
     "lint": "eslint ./src --ext .ts,.tsx",
     "prepublishOnly": "yarn clean && tsc --project tsconfig.prod.json && tscpaths -p tsconfig.prod.json -s ./src -o ./dist",
     "version": "standard-changelog && git add CHANGELOG.md package.json && git commit -m \"release: bump version to v${npm_package_version}\"",


### PR DESCRIPTION
# What

Fix the `clean` script used in build proccess on our CI.

# Why

The project was using `rimraf` package to remove `./dist` folder on CI deploy scripts.
This package was causing an error, blocking the automatic deploy to NPM.
The first hypothesis was the install script wasn't being trigged, even we follwed the docs to create the script. We tried some differents ways and none of them resolved this problem.
The second hypotesis was the CI was calling `rimraf`globally instead of locally. It is unlikely to happen, once we are running `yarn rimraf`.
Finally, instead of trying to fix `rimraf`'s use, we are running `rm -rf` directly on `clean` script. It is more performatic (althoug this is a small work) and we are aceppting the tradeoff of using it instead of a cross-platform package.

Also, we removed `rimraf` dependency.

# How

- changing `clean` script to use `rm -rf`
-  removing `rimraf` dependency


[AST-10](https://produtomagnetis.atlassian.net/browse/AST-10?atlOrigin=eyJpIjoiZjk2N2ZiMTg4NWZmNGIxN2EyMzAwZmMwZDU4ZTczMjkiLCJwIjoiaiJ9)
