### PR TITLE
[AST-12] Fix text input error layout

### DIFF
--- a/src/components/Inputs/InputErrorMessage.tsx
+++ b/src/components/Inputs/InputErrorMessage.tsx
@@ -19,9 +19,7 @@ function InputErrorMessage({ error, hasError }: InputErrorMessageProps) {
 
 const styles = StyleSheet.create({
   errorContainer: {
-    position: 'absolute',
-    bottom: 0,
-    left: 16,
+    margin: 5,
   },
   error: {
     fontFamily: lato,

--- a/src/components/Inputs/InputEyeToggle.tsx
+++ b/src/components/Inputs/InputEyeToggle.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import { Pressable, StyleSheet } from 'react-native';
-import { colors } from '@magnetis/astro-galaxy-tokens';
 
 import { EyeClosedIcon, EyeOpenIcon } from '@components/Icons';
+import { getInputBorderColor } from './utils';
 
 interface InputEyeToggleProps {
+  hasError?: boolean;
+  hasFocus?: boolean;
   visible: boolean;
   onPress: () => void;
   large: boolean;
 }
 
-function InputEyeToggle({ visible, onPress, large }: InputEyeToggleProps) {
-  const iconProps = { color: colors.moon900, width: 32, height: 32 };
+function InputEyeToggle({ hasError = false, hasFocus = false, visible, onPress, large }: InputEyeToggleProps) {
+  const iconProps = {
+    color: getInputBorderColor({ disabled: false, hasError, hasFocus, validated: false }),
+    width: 32,
+    height: 32,
+  };
 
   if (visible) {
     return (

--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -114,19 +114,24 @@ function TextInput({
           ref={inputRef}
           onChangeText={handleOnChangeText}
         />
-        <InputStatusIcon hasError={hasError} isValidated={isValidated} large={large} />
+        {!password && <InputStatusIcon hasError={hasError} isValidated={isValidated} large={large} />}
       </Pressable>
-      {password ? (
-        <InputEyeToggle large={large} visible={showPassword} onPress={togglePasswordVisibility} />
-      ) : (
-        <InputErrorMessage error={error} hasError={hasError} />
+      {password && (
+        <InputEyeToggle
+          hasError={hasError}
+          hasFocus={hasFocus}
+          large={large}
+          visible={showPassword}
+          onPress={togglePasswordVisibility}
+        />
       )}
+      {hasError && <InputErrorMessage error={error} hasError={hasError} />}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  wrapper: { paddingBottom: 22 },
+  wrapper: { paddingBottom: 12 },
   container: {
     borderWidth: 1,
     borderRadius: 8,

--- a/src/components/Inputs/__tests__/InputErrorMessage.test.tsx
+++ b/src/components/Inputs/__tests__/InputErrorMessage.test.tsx
@@ -7,9 +7,7 @@ describe('InputErrorMessage', () => {
   it('renders correctly when hasError is true', () => {
     const { getByText, getByTestId } = render(<InputErrorMessage error="Error" hasError />);
 
-    expect(getByTestId('InputErrorMessage').props.style[0]).toEqual(
-      expect.objectContaining({ position: 'absolute', bottom: 0, left: 16 })
-    );
+    expect(getByTestId('InputErrorMessage').props.style[0]).toEqual(expect.objectContaining({ margin: 5 }));
     expect(getByTestId('InputErrorMessage').props.style[1]).toEqual(expect.objectContaining({ opacity: 1 }));
     expect(getByText('Error').props.style).toEqual(
       expect.objectContaining({
@@ -23,9 +21,7 @@ describe('InputErrorMessage', () => {
   it('renders correctly when hasError is false', () => {
     const { getByText, getByTestId } = render(<InputErrorMessage error="Error" hasError={false} />);
 
-    expect(getByTestId('InputErrorMessage').props.style[0]).toEqual(
-      expect.objectContaining({ position: 'absolute', bottom: 0, left: 16 })
-    );
+    expect(getByTestId('InputErrorMessage').props.style[0]).toEqual(expect.objectContaining({ margin: 5 }));
     expect(getByTestId('InputErrorMessage').props.style[1]).toEqual(expect.objectContaining({ opacity: 0 }));
     expect(getByText('Error').props.style).toEqual(
       expect.objectContaining({

--- a/src/components/Inputs/__tests__/TextInput.test.tsx
+++ b/src/components/Inputs/__tests__/TextInput.test.tsx
@@ -30,7 +30,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onBlur();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
 
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
@@ -72,7 +72,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onBlur();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
 
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
@@ -116,7 +116,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onBlur();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
 
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
@@ -174,7 +174,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -216,7 +216,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -260,7 +260,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -290,7 +290,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -316,7 +316,7 @@ describe('TextInput', () => {
   it('renders correctly on blur state when large is true', () => {
     const { getByTestId } = render(<TextInput {...props} large />);
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -346,7 +346,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -376,7 +376,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -406,7 +406,7 @@ describe('TextInput', () => {
       getByTestId('TextInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('TextInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('TextInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,


### PR DESCRIPTION
# What
- Fix `TextInput`

# Why
- Fix problems raised after components implemented at `mobile-app`

# How
- Fix `TextInput` erro message layout
- Add `hasError` and `hasFocus` to `InputEyeToggle` component
- Fix `TextInput` behavior when is `password` field

[AST-12](https://produtomagnetis.atlassian.net/browse/AST-12)
