### PR TITLE
[AST-7 | PRIM-666] fix(basebutton): min hitslop seted when button is smaller then 48

### DIFF
--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -1,5 +1,13 @@
-import React, { ReactElement } from 'react';
-import { View, StyleSheet, ActivityIndicator, Pressable, PressableProps } from 'react-native';
+import React, { ReactElement, useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  ActivityIndicator,
+  Pressable,
+  PressableProps,
+  LayoutChangeEvent,
+  Insets,
+} from 'react-native';
 
 import { getBorderRadius, getButtonPadding } from './utils';
 import { ButtonSize } from './types';
@@ -36,6 +44,10 @@ const styles = StyleSheet.create({
   },
 });
 
+type HitSlop = null | Insets | number;
+
+const MIN_HIT_SLOP = 48;
+
 function BaseButton({
   loading = false,
   disabled = false,
@@ -47,6 +59,8 @@ function BaseButton({
   hasIcon = false,
   ...props
 }: BaseButtonProps) {
+  const [hitSlop, setHitSlop] = useState<HitSlop>({ top: 0, bottom: 0, left: 0, right: 0 });
+
   const computedStyles: any = {
     ...getButtonPadding(size, { noHorizontalPadding, hasIcon }),
     backgroundColor: props.backgroundColor,
@@ -66,10 +80,35 @@ function BaseButton({
     disabled: disabled,
     style: [styles.button, computedStyles],
     testID: props.testID,
+    hitSlop: typeof props.hitSlop !== 'undefined' ? props.hitSlop : hitSlop,
   };
 
+  function adjustHitSlop(event: LayoutChangeEvent) {
+    const { width, height } = event.nativeEvent.layout;
+    if (width < MIN_HIT_SLOP || height < MIN_HIT_SLOP) {
+      const horizontalOffset = width < MIN_HIT_SLOP ? (MIN_HIT_SLOP - width) / 2 : 0;
+      const verticalOffset = height < MIN_HIT_SLOP ? (MIN_HIT_SLOP - height) / 2 : 0;
+      const newHitSlop = {
+        top: verticalOffset,
+        bottom: verticalOffset,
+        left: horizontalOffset,
+        right: horizontalOffset,
+      };
+      setHitSlop(newHitSlop);
+    }
+  }
+
+  function onLayoutButton(event: LayoutChangeEvent) {
+    if (props.onLayout) {
+      props.onLayout(event);
+    }
+    if (typeof props.hitSlop === 'undefined') {
+      adjustHitSlop(event);
+    }
+  }
+
   return (
-    <Pressable accessibilityRole="button" {...props} {...pressableProps}>
+    <Pressable accessibilityRole="button" {...props} {...pressableProps} onLayout={onLayoutButton}>
       <View style={{ alignItems: 'center', justifyContent: 'center', flex: fill ? 1 : 0 }}>
         <View style={{ opacity: loading ? 0 : 1 }}>{children}</View>
         {loading && (

--- a/src/components/Buttons/__tests__/BaseButton.test.tsx
+++ b/src/components/Buttons/__tests__/BaseButton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, act } from '@testing-library/react-native';
 import { colors } from '@magnetis/astro-galaxy-tokens';
 
 import BaseButton from '../BaseButton';
@@ -91,5 +91,164 @@ describe('BaseButton', () => {
     const baseButtonStyle = Object.assign({}, ...baseButton.props.style);
 
     expect(baseButtonStyle.width).toEqual('100%');
+  });
+
+  it('has min hit slop 50X48 when button width and height is small', () => {
+    const { getByTestId } = render(
+      <BaseButton {...props} fill>
+        <ButtonText />
+      </BaseButton>
+    );
+
+    const baseButton = getByTestId('BaseButton');
+    act(() => {
+      baseButton.props.onLayout({
+        nativeEvent: {
+          layout: {
+            height: 20,
+            width: 20,
+          },
+        },
+      });
+    });
+
+    expect(baseButton.props.hitSlop).toStrictEqual({
+      top: 14,
+      bottom: 14,
+      left: 14,
+      right: 14,
+    });
+  });
+
+  it('has min hit slop 48X48 when button width is small', () => {
+    const { getByTestId } = render(
+      <BaseButton {...props} fill>
+        <ButtonText />
+      </BaseButton>
+    );
+
+    const baseButton = getByTestId('BaseButton');
+    act(() => {
+      baseButton.props.onLayout({
+        nativeEvent: {
+          layout: {
+            height: 50,
+            width: 20,
+          },
+        },
+      });
+    });
+
+    expect(baseButton.props.hitSlop).toStrictEqual({
+      top: 0,
+      bottom: 0,
+      left: 14,
+      right: 14,
+    });
+  });
+
+  it('has min hit slop 48X50 when button height is small', () => {
+    const { getByTestId } = render(
+      <BaseButton {...props} fill>
+        <ButtonText />
+      </BaseButton>
+    );
+
+    const baseButton = getByTestId('BaseButton');
+    act(() => {
+      baseButton.props.onLayout({
+        nativeEvent: {
+          layout: {
+            height: 20,
+            width: 50,
+          },
+        },
+      });
+    });
+
+    expect(baseButton.props.hitSlop).toStrictEqual({
+      top: 14,
+      bottom: 14,
+      left: 0,
+      right: 0,
+    });
+  });
+
+  it('has min hit slop 60X50 when button height is bigger then minimum', () => {
+    const { getByTestId } = render(
+      <BaseButton {...props} fill>
+        <ButtonText />
+      </BaseButton>
+    );
+
+    const baseButton = getByTestId('BaseButton');
+    act(() => {
+      baseButton.props.onLayout({
+        nativeEvent: {
+          layout: {
+            height: 50,
+            width: 50,
+          },
+        },
+      });
+    });
+
+    expect(baseButton.props.hitSlop).toStrictEqual({
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    });
+  });
+
+  it('has hit slop passed when button width and height is small, but hit slop prop has been passed', () => {
+    const { getByTestId } = render(
+      <BaseButton {...props} fill hitSlop={0}>
+        <ButtonText />
+      </BaseButton>
+    );
+
+    const baseButton = getByTestId('BaseButton');
+    act(() => {
+      baseButton.props.onLayout({
+        nativeEvent: {
+          layout: {
+            height: 20,
+            width: 20,
+          },
+        },
+      });
+    });
+
+    expect(baseButton.props.hitSlop).toStrictEqual({ bottom: 0, left: 0, right: 0, top: 0 });
+  });
+
+  it('has onLayout called if user set this prop', () => {
+    const onLayout = jest.fn();
+    const { getByTestId } = render(
+      <BaseButton {...props} fill onLayout={onLayout}>
+        <ButtonText />
+      </BaseButton>
+    );
+
+    const baseButton = getByTestId('BaseButton');
+    act(() => {
+      baseButton.props.onLayout({
+        nativeEvent: {
+          layout: {
+            height: 20,
+            width: 20,
+          },
+        },
+      });
+    });
+
+    expect(onLayout).toBeCalledTimes(1);
+    expect(baseButton.props.hitSlop).toStrictEqual({
+      top: 14,
+      bottom: 14,
+      left: 14,
+      right: 14,
+    });
   });
 });


### PR DESCRIPTION
# What

- calculate and set hitslop for small buttons

# Why

- to follow good UX practices and simplify access to small buttons

# How

- using the onLayout prop to obtain the height and width of the button and calculate how much is left to meet the minimum requirements

# Sample
<img src="https://user-images.githubusercontent.com/39625749/107051726-8eee9100-67ab-11eb-8c1f-83d68022abe3.png" width="300" />

[PRIM-666](https://produtomagnetis.atlassian.net/browse/PRIM-666)
[AST-7](https://produtomagnetis.atlassian.net/browse/AST-7)
