### PR TITLE
[AST-20] Fix Tab when has single item

### DIFF
--- a/src/components/ControlsToggles/Tabs.tsx
+++ b/src/components/ControlsToggles/Tabs.tsx
@@ -162,7 +162,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    flex: 1,
+    flex: 0,
   },
   itemWithBorderBottom: {
     borderRadius: 0,

--- a/src/components/ControlsToggles/__tests__/Tabs.test.tsx
+++ b/src/components/ControlsToggles/__tests__/Tabs.test.tsx
@@ -60,7 +60,7 @@ describe('Tabs', () => {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'center',
-        flex: 1,
+        flex: 0,
       })
     );
 
@@ -173,7 +173,7 @@ describe('Tabs', () => {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'center',
-        flex: 1,
+        flex: 0,
       })
     );
 
@@ -376,7 +376,7 @@ describe('Tabs', () => {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'center',
-        flex: 1,
+        flex: 0,
       })
     );
 
@@ -480,7 +480,7 @@ describe('Tabs', () => {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'center',
-        flex: 1,
+        flex: 0,
       })
     );
 


### PR DESCRIPTION
# What

Fix tab item when single child container.

# Why
Before this fix, tab item was stretching to fill tab container.

# How
Change item flex style from one to zero.
