### PR TITLE
release: bump version to v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,64 +1,58 @@
-## [1.3.1](https://github.com/magnetis/astro-native/compare/v1.3.0...v1.3.1) (2020-12-29)
-
+# [1.4.0](https://github.com/magnetis/astro-native/compare/v1.3.1...v1.4.0) (2021-02-10)
 
 ### Bug Fixes
 
-* **TextInput:** update state when value changes ([a0b2d74](https://github.com/magnetis/astro-native/commit/a0b2d74e5ff808462651207ea1a6e4aede7df1a3))
+- **basebutton:** min hitslop seted when button is smaller then 48 ([671a345](https://github.com/magnetis/astro-native/commit/671a3450f122ed013c539f1dcde1f5cbcf1225ef))
+- **textinput:** fix text input error layout ([c2644fc](https://github.com/magnetis/astro-native/commit/c2644fcd5873df1d6466c96a49dffff1e3bb821a))
 
+### Features
 
+- **tabs:** add borderBottom option ([72f7e6a](https://github.com/magnetis/astro-native/commit/72f7e6aadc01cd35c244843a0abb74b5332298e2))
+
+## [1.3.1](https://github.com/magnetis/astro-native/compare/v1.3.0...v1.3.1) (2020-12-29)
+
+### Bug Fixes
+
+- **TextInput:** update state when value changes ([a0b2d74](https://github.com/magnetis/astro-native/commit/a0b2d74e5ff808462651207ea1a6e4aede7df1a3))
 
 # [1.3.0](https://github.com/magnetis/astro-native/compare/v1.2.0...v1.3.0) (2020-12-28)
 
-
 ### Bug Fixes
 
-* **TextInput:** fix input text label animation ([9d0b667](https://github.com/magnetis/astro-native/commit/9d0b667c6d520bdfa3d24e3729bc71182db4c54d))
-
+- **TextInput:** fix input text label animation ([9d0b667](https://github.com/magnetis/astro-native/commit/9d0b667c6d520bdfa3d24e3729bc71182db4c54d))
 
 ### Features
 
-* **Title:** Implement Title component ([f2b242f](https://github.com/magnetis/astro-native/commit/f2b242fce8118fd3c5773a58481edbe3fc7263c6))
-
-
+- **Title:** Implement Title component ([f2b242f](https://github.com/magnetis/astro-native/commit/f2b242fce8118fd3c5773a58481edbe3fc7263c6))
 
 # [1.2.0](https://github.com/magnetis/astro-native/compare/v1.1.0...v1.2.0) (2020-12-22)
 
-
 ### Features
 
-* **CurrencyInput:** Implement controlled input support ([1d27f5c](https://github.com/magnetis/astro-native/commit/1d27f5c8edfb1251a58b4cf56de66456c2e8f663))
-
-
+- **CurrencyInput:** Implement controlled input support ([1d27f5c](https://github.com/magnetis/astro-native/commit/1d27f5c8edfb1251a58b4cf56de66456c2e8f663))
 
 # [1.1.0](https://github.com/magnetis/astro-native/compare/v1.0.3...v1.1.0) (2020-12-18)
 
-
 ### Bug Fixes
 
-* **ControlInput:** fix format bevahior ([2b3fbc4](https://github.com/magnetis/astro-native/commit/2b3fbc461f2c784573299e9c18ce79c9a4ca2f79))
-
+- **ControlInput:** fix format bevahior ([2b3fbc4](https://github.com/magnetis/astro-native/commit/2b3fbc461f2c784573299e9c18ce79c9a4ca2f79))
 
 ### Features
 
-* **Inputs:** Implement Currency Input ([c732d0a](https://github.com/magnetis/astro-native/commit/c732d0a36b640754c589b20253d982f47c5a2b8b))
-
-
+- **Inputs:** Implement Currency Input ([c732d0a](https://github.com/magnetis/astro-native/commit/c732d0a36b640754c589b20253d982f47c5a2b8b))
 
 ## [1.0.3](https://github.com/magnetis/astro-native/compare/v1.0.2...v1.0.3) (2020-12-15)
 
-
 ### Bug Fixes
 
-* **Buttons:** change isDisabled prop to `disabled` ([8ea62a0](https://github.com/magnetis/astro-native/commit/8ea62a0276fee107f8761f683a7e4aec42268b11))
-* **Buttons:** change isLoading prop to `loading` ([c8c6ed1](https://github.com/magnetis/astro-native/commit/c8c6ed1f2506636ca9aa3dd7882feb655deca0da))
-* **Checkbox:** change isIndeterminate props to `indeterminate` ([20e0224](https://github.com/magnetis/astro-native/commit/20e0224a15b6b1d9a763dd0782db6450803ed3f9))
-* **ControlInput:** forward testID prop to input component ([6a24b6a](https://github.com/magnetis/astro-native/commit/6a24b6a85d66ab98f51ac1f2d7e7fc73595a5b89))
-* **Controls&Toggles:** change isDisabled prop to `disabled` ([7e5a08b](https://github.com/magnetis/astro-native/commit/7e5a08b99c8aedcf807191dfe5d1feb7ca9871f6))
-* **MaskedInput:** fix text align ([435f9f4](https://github.com/magnetis/astro-native/commit/435f9f4dcb12d5b587211c44a3c589d05c373102))
-* **Radio:** change isSelected prop to `selected`` ([14cc701](https://github.com/magnetis/astro-native/commit/14cc70100075ecdf76bdce87e885bf328f50480c))
-* **TextInput:** Fix password behavior ([0712b1c](https://github.com/magnetis/astro-native/commit/0712b1c2a9fe3ba17b7f4a89afe33720781978d5))
-
-
+- **Buttons:** change isDisabled prop to `disabled` ([8ea62a0](https://github.com/magnetis/astro-native/commit/8ea62a0276fee107f8761f683a7e4aec42268b11))
+- **Buttons:** change isLoading prop to `loading` ([c8c6ed1](https://github.com/magnetis/astro-native/commit/c8c6ed1f2506636ca9aa3dd7882feb655deca0da))
+- **Checkbox:** change isIndeterminate props to `indeterminate` ([20e0224](https://github.com/magnetis/astro-native/commit/20e0224a15b6b1d9a763dd0782db6450803ed3f9))
+- **ControlInput:** forward testID prop to input component ([6a24b6a](https://github.com/magnetis/astro-native/commit/6a24b6a85d66ab98f51ac1f2d7e7fc73595a5b89))
+- **Controls&Toggles:** change isDisabled prop to `disabled` ([7e5a08b](https://github.com/magnetis/astro-native/commit/7e5a08b99c8aedcf807191dfe5d1feb7ca9871f6))
+- **MaskedInput:** fix text align ([435f9f4](https://github.com/magnetis/astro-native/commit/435f9f4dcb12d5b587211c44a3c589d05c373102))
+- **Radio:** change isSelected prop to `selected`` ([14cc701](https://github.com/magnetis/astro-native/commit/14cc70100075ecdf76bdce87e885bf328f50480c))
+- **TextInput:** Fix password behavior ([0712b1c](https://github.com/magnetis/astro-native/commit/0712b1c2a9fe3ba17b7f4a89afe33720781978d5))
 
 ## [1.0.2](https://github.com/magnetis/astro-native/compare/v1.0.1...v1.0.2) (2020-12-11)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-native",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Astro components for React Native",
   "homepage": "https://astro-galaxy.magnetis.com.br/",
   "files": [


### PR DESCRIPTION
### Bug Fixes

* **basebutton:** min hitslop seted when button is smaller then 48 ([671a345](https://github.com/magnetis/astro-native/commit/671a3450f122ed013c539f1dcde1f5cbcf1225ef))
* **textinput:** fix text input error layout ([c2644fc](https://github.com/magnetis/astro-native/commit/c2644fcd5873df1d6466c96a49dffff1e3bb821a))


### Features

* **tabs:** add borderBottom option ([72f7e6a](https://github.com/magnetis/astro-native/commit/72f7e6aadc01cd35c244843a0abb74b5332298e2))

