### PR TITLE
[AST-53] Fix currency input layout

### DIFF
--- a/src/components/Inputs/MaskedInput.tsx
+++ b/src/components/Inputs/MaskedInput.tsx
@@ -103,13 +103,13 @@ function MaskedInput({
         />
         <InputStatusIcon hasError={hasError} isValidated={isValidated} large={large} />
       </Pressable>
-      <InputErrorMessage error={error} hasError={hasError} />
+      {hasError && <InputErrorMessage error={error} hasError={hasError} />}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  wrapper: { paddingBottom: 22 },
+  wrapper: { paddingBottom: 12 },
   container: {
     borderWidth: 1,
     borderRadius: 8,

--- a/src/components/Inputs/__tests__/MaskedInput.test.tsx
+++ b/src/components/Inputs/__tests__/MaskedInput.test.tsx
@@ -25,7 +25,7 @@ describe('MaskedInput', () => {
       getByTestId('MaskedInput.Input').props.onBlur();
     });
 
-    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
 
     expect(getByTestId('MaskedInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
@@ -57,7 +57,7 @@ describe('MaskedInput', () => {
       getByTestId('MaskedInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
 
     expect(getByTestId('MaskedInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
@@ -89,7 +89,7 @@ describe('MaskedInput', () => {
       getByTestId('MaskedInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('MaskedInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -119,7 +119,7 @@ describe('MaskedInput', () => {
       getByTestId('MaskedInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('MaskedInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -145,7 +145,7 @@ describe('MaskedInput', () => {
   it('renders correctly on blur state when large is true', () => {
     const { getByTestId } = render(<MaskedInput {...props} large />);
 
-    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('MaskedInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -175,7 +175,7 @@ describe('MaskedInput', () => {
       getByTestId('MaskedInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('MaskedInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -205,7 +205,7 @@ describe('MaskedInput', () => {
       getByTestId('MaskedInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('MaskedInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -229,13 +229,13 @@ describe('MaskedInput', () => {
   });
 
   it('renders correctly when error is truthy and large is true', () => {
-    const { getByTestId } = render(<MaskedInput {...props} error="error" large touched />);
+    const { getByText, getByTestId } = render(<MaskedInput {...props} error="error" large touched />);
 
     act(() => {
       getByTestId('MaskedInput.Input').props.onFocus();
     });
 
-    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 22 }));
+    expect(getByTestId('MaskedInput').props.style).toEqual(expect.objectContaining({ paddingBottom: 12 }));
     expect(getByTestId('MaskedInput.Container').props.style[0]).toEqual(
       expect.objectContaining({
         borderWidth: 1,
@@ -256,6 +256,8 @@ describe('MaskedInput', () => {
     expect(getByTestId('MaskedInput.Input').props.style[1]).toEqual(
       expect.objectContaining({ paddingLeft: 24, fontSize: 24, paddingRight: 56, textAlign: 'left' })
     );
+
+    expect(getByText('error')).toBeTruthy();
   });
 
   it('calls onChangeText when input text changes', () => {


### PR DESCRIPTION
# What

Fix `CurrencyInput` layout

# Why

The `CurrencyInput` renders useless and wrong spaces above and under input

# How

Add validation to render the error message on `MaskedInput` (this is the base component of `CurrencyInput`)

# Sample

<img src="https://user-images.githubusercontent.com/13890272/108888086-ca7dbd80-75e9-11eb-9a64-0f1345dd0f7e.gif" height="500" width="250" />
 
# QA

Run the project, and test pass an error message at story book, needs to render default and error layout correctly

[AST-53](https://produtomagnetis.atlassian.net/browse/AST-53)
