### PR TITLE
Add `release` type to commit lint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,21 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
+  parserPreset: 'conventional-changelog-conventionalcommits',
+  rules: {
+    'body-leading-blank': [1, 'always'],
+    'body-max-line-length': [2, 'always', 100],
+    'footer-leading-blank': [1, 'always'],
+    'footer-max-line-length': [2, 'always', 100],
+    'header-max-length': [2, 'always', 100],
+    'scope-case': [2, 'always', ['pascal-case', 'lower-case']],
+    'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
+    'subject-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
+    'type-case': [2, 'always', 'lower-case'],
+    'type-empty': [2, 'never'],
+    'type-enum': [
+      2,
+      'always',
+      ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'release'],
+    ],
+  },
 };


### PR DESCRIPTION
# What
Add `release` type to commit lint config.

# Why
If that change wasn't made, would be impossible to run `npm version` without message lint giving error.

# How
By copying [this example](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/config-conventional/index.js) and modifying where needed.

