### PR TITLE
[AST-61] Fix secure text entry to be true when input is password

### DIFF
--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -105,7 +105,7 @@ function TextInput({
         />
         <RNTextInput
           {...props}
-          secureTextEntry={password && !showPassword}
+          secureTextEntry={showPassword}
           testID={testID}
           editable={!disabled}
           style={[styles.input, computedInputStyles]}

--- a/src/components/Inputs/__tests__/TextInput.test.tsx
+++ b/src/components/Inputs/__tests__/TextInput.test.tsx
@@ -440,17 +440,17 @@ describe('TextInput', () => {
   it('hides value when password is set to true and renders eye toggle', () => {
     const { getByTestId, queryByTestId, update } = render(<TextInput {...props} />);
 
-    expect(queryByTestId('InputEyeToggle.EyeClosed')).toBeNull();
+    expect(queryByTestId('InputEyeToggle.EyeOpen')).toBeNull();
 
     update(<TextInput {...props} password />);
 
     expect(queryByTestId('InputEyeToggle.EyeClosed')).not.toBeNull();
-    expect(getByTestId('TextInput.Input').props.secureTextEntry).toBe(true);
+    expect(getByTestId('TextInput.Input').props.secureTextEntry).toBe(false);
 
     fireEvent.press(getByTestId('InputEyeToggle.EyeClosed'));
 
     expect(queryByTestId('InputEyeToggle.EyeOpen')).not.toBeNull();
-    expect(getByTestId('TextInput.Input').props.secureTextEntry).toBe(false);
+    expect(getByTestId('TextInput.Input').props.secureTextEntry).toBe(true);
   });
 
   it('does not render error state when touched is false', () => {


### PR DESCRIPTION
# What

Fix `TextInput` type password

# Why

The `TextInput` type password not display `password manager` native from device

# How

Only show `secureTextEntry` when `showPassword` is true.

# Sample

https://user-images.githubusercontent.com/9031279/111193780-4dff4e80-8599-11eb-8800-8b56c595f2cf.mp4

[AST-61](https://produtomagnetis.atlassian.net/browse/AST-61)