### PR TITLE
[AST-57] [AST-58] [PMF-156] [PMF-155] feat(baseicon): add pressable, hitslop and size prop into icon

### DIFF
--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useCallback, useState } from 'react';
 import { View, StyleSheet, ActivityIndicator, Pressable, PressableProps, LayoutChangeEvent } from 'react-native';
 
 import type { HitSlop } from '../types';
@@ -74,20 +74,19 @@ function BaseButton({
     hitSlop: typeof props.hitSlop !== 'undefined' ? props.hitSlop : hitSlop,
   };
 
-  function adjustHitSlop(event: LayoutChangeEvent) {
-    const { width, height } = event.nativeEvent.layout;
-    const newHitSlop = getFixedHitSlop({ width, height });
-    setHitSlop(newHitSlop);
-  }
-
-  function onLayoutButton(event: LayoutChangeEvent) {
-    if (props.onLayout) {
-      props.onLayout(event);
-    }
-    if (typeof props.hitSlop === 'undefined') {
-      adjustHitSlop(event);
-    }
-  }
+  const onLayoutButton = useCallback(
+    (event: LayoutChangeEvent) => {
+      if (props.onLayout) {
+        props.onLayout(event);
+      }
+      if (typeof props.hitSlop === 'undefined') {
+        const { width, height } = event.nativeEvent.layout;
+        const newHitSlop = getFixedHitSlop({ width, height });
+        setHitSlop(newHitSlop);
+      }
+    },
+    [props.onLayout, props.hitSlop]
+  );
 
   return (
     <Pressable accessibilityRole="button" {...props} {...pressableProps} onLayout={onLayoutButton}>

--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -1,16 +1,11 @@
 import React, { ReactElement, useState } from 'react';
-import {
-  View,
-  StyleSheet,
-  ActivityIndicator,
-  Pressable,
-  PressableProps,
-  LayoutChangeEvent,
-  Insets,
-} from 'react-native';
+import { View, StyleSheet, ActivityIndicator, Pressable, PressableProps, LayoutChangeEvent } from 'react-native';
 
+import type { HitSlop } from '../types';
+import { getFixedHitSlop } from '../utils';
+
+import type { ButtonSize } from './types';
 import { getBorderRadius, getButtonPadding } from './utils';
-import { ButtonSize } from './types';
 
 interface BaseButtonProps extends PressableProps {
   children: ReactElement;
@@ -43,10 +38,6 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
 });
-
-type HitSlop = null | Insets | number;
-
-const MIN_HIT_SLOP = 48;
 
 function BaseButton({
   loading = false,
@@ -85,17 +76,8 @@ function BaseButton({
 
   function adjustHitSlop(event: LayoutChangeEvent) {
     const { width, height } = event.nativeEvent.layout;
-    if (width < MIN_HIT_SLOP || height < MIN_HIT_SLOP) {
-      const horizontalOffset = width < MIN_HIT_SLOP ? (MIN_HIT_SLOP - width) / 2 : 0;
-      const verticalOffset = height < MIN_HIT_SLOP ? (MIN_HIT_SLOP - height) / 2 : 0;
-      const newHitSlop = {
-        top: verticalOffset,
-        bottom: verticalOffset,
-        left: horizontalOffset,
-        right: horizontalOffset,
-      };
-      setHitSlop(newHitSlop);
-    }
+    const newHitSlop = getFixedHitSlop({ width, height });
+    setHitSlop(newHitSlop);
   }
 
   function onLayoutButton(event: LayoutChangeEvent) {

--- a/src/components/Icons/BaseIcon.tsx
+++ b/src/components/Icons/BaseIcon.tsx
@@ -1,8 +1,12 @@
 import React, { ReactNode } from 'react';
+import { Pressable } from 'react-native';
 import Svg, { Defs } from 'react-native-svg';
 
 import type { IconProps } from './types';
 import GradientConfig from './GradientConfig';
+
+import type { HitSlop } from '../types';
+import { getFixedHitSlop } from '@components/utils';
 
 interface BaseIconProps extends IconProps {
   children: ReactNode;
@@ -10,9 +14,42 @@ interface BaseIconProps extends IconProps {
   id: string;
 }
 
-function BaseIcon({ viewBox = '0 0 32 32', height = 32, width = 32, children, gradient, id, ...props }: BaseIconProps) {
+function BaseIcon({
+  viewBox = '0 0 32 32',
+  height = 32,
+  width = 32,
+  children,
+  gradient,
+  id,
+  size,
+  onPress,
+  hitSlop,
+  testID,
+  ...props
+}: BaseIconProps) {
+  const sizeProps = {
+    width: Number(size ?? width),
+    height: Number(size ?? height),
+  };
+
+  if (onPress) {
+    const newHitSlop: HitSlop = typeof hitSlop === 'undefined' ? getFixedHitSlop(sizeProps) : hitSlop;
+
+    return (
+      <Pressable accessibilityRole="button" onPress={onPress} hitSlop={newHitSlop} testID={testID}>
+        <Svg {...sizeProps} viewBox={viewBox} {...props}>
+          {gradient && (
+            <Defs>
+              <GradientConfig gradient={gradient} id={id} />
+            </Defs>
+          )}
+          {children}
+        </Svg>
+      </Pressable>
+    );
+  }
   return (
-    <Svg width={width} height={height} viewBox={viewBox} {...props}>
+    <Svg {...sizeProps} viewBox={viewBox} {...props} testID={testID}>
       {gradient && (
         <Defs>
           <GradientConfig gradient={gradient} id={id} />

--- a/src/components/Icons/__tests__/BaseIcon.test.tsx
+++ b/src/components/Icons/__tests__/BaseIcon.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { Path } from 'react-native-svg';
 
@@ -138,5 +138,99 @@ describe('BaseIcon', () => {
         </RNSVGGroup>
       </RNSVGSvgView>
     `);
+  });
+
+  it('when icon does not have onPress', () => {
+    const { getByTestId } = render(
+      <BaseIcon id="BaseIcon" gradient="nebulosa" testID="BaseIcon">
+        <Path fillRule="evenodd" clipRule="evenodd" d="M16.5" fill="red" />
+      </BaseIcon>
+    );
+
+    expect(getByTestId('BaseIcon').props.hitSlop).toBeUndefined();
+  });
+
+  it('when icon has onPress', () => {
+    const onPress = jest.fn();
+
+    const { getByTestId } = render(
+      <BaseIcon id="BaseIcon" gradient="nebulosa" testID="BaseIcon" onPress={onPress}>
+        <Path fillRule="evenodd" clipRule="evenodd" d="M16.5" fill="red" />
+      </BaseIcon>
+    );
+
+    const baseIcon = getByTestId('BaseIcon');
+
+    expect(baseIcon.props.hitSlop).toBeDefined();
+
+    fireEvent.press(baseIcon);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('when icon has onPress and is too small', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <BaseIcon id="BaseIcon" gradient="nebulosa" testID="BaseIcon" width={16} height={'32'} onPress={onPress}>
+        <Path fillRule="evenodd" clipRule="evenodd" d="M16.5" fill="red" />
+      </BaseIcon>
+    );
+
+    expect(getByTestId('BaseIcon').props.hitSlop).toStrictEqual({
+      top: 8,
+      bottom: 8,
+      left: 16,
+      right: 16,
+    });
+  });
+
+  it('when icon has onPress and is too large', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <BaseIcon id="BaseIcon" gradient="nebulosa" testID="BaseIcon" width={'64'} height={48} onPress={onPress}>
+        <Path fillRule="evenodd" clipRule="evenodd" d="M16.5" fill="red" />
+      </BaseIcon>
+    );
+
+    expect(getByTestId('BaseIcon').props.hitSlop).toStrictEqual({
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    });
+  });
+
+  it('when icon has size prop', () => {
+    const { getByTestId } = render(
+      <BaseIcon id="BaseIcon" gradient="nebulosa" testID="BaseIcon" size={64}>
+        <Path fillRule="evenodd" clipRule="evenodd" d="M16.5" fill="red" />
+      </BaseIcon>
+    );
+
+    expect(getByTestId('BaseIcon').props.width).toBe(64);
+    expect(getByTestId('BaseIcon').props.height).toBe(64);
+  });
+
+  it('when icon has onPress and is too small but has hitSlop prop', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <BaseIcon
+        id="BaseIcon"
+        gradient="nebulosa"
+        testID="BaseIcon"
+        width={16}
+        height={'32'}
+        onPress={onPress}
+        hitSlop={{
+          bottom: 10,
+          left: 10,
+          right: 10,
+          top: 10,
+        }}
+      >
+        <Path fillRule="evenodd" clipRule="evenodd" d="M16.5" fill="red" />
+      </BaseIcon>
+    );
+
+    expect(getByTestId('BaseIcon').props.hitSlop).toStrictEqual({ bottom: 10, left: 10, right: 10, top: 10 });
   });
 });

--- a/src/components/Icons/stories/index.tsx
+++ b/src/components/Icons/stories/index.tsx
@@ -18,10 +18,11 @@ Object.keys(icons).forEach((key) => {
   const Icon = icons[key];
   iconsStories.add(key.replace('Icon', ''), () => (
     <Icon
-      width={number('width', 64)}
-      height={number('height', 64)}
+      width={number('width', 16)}
+      height={number('height', 16)}
       gradient={select('gradient', gradientOptions, undefined) || undefined}
       color={select('color', colorOptions, colors.uranus500)}
+      onPress={() => console.log('Pressed')}
     />
   ));
 });

--- a/src/components/Icons/types.ts
+++ b/src/components/Icons/types.ts
@@ -1,9 +1,10 @@
 import type { SvgProps } from 'react-native-svg';
 import { Colors } from '@magnetis/astro-galaxy-tokens';
+import type { GestureResponderEvent } from 'react-native';
 
 import { GradientID } from '@tokens/gradients';
 
-export interface IconProps extends Omit<SvgProps, 'color'> {
+export interface IconProps extends Omit<SvgProps, 'color' | 'onPress'> {
   /** Id for icon gradient. Recomended to pass a unique value. */
   id?: string;
   /** A valid gradient name from `GradientID` */
@@ -14,6 +15,10 @@ export interface IconProps extends Omit<SvgProps, 'color'> {
   height?: number | string;
   /** A valid color for Astro's colors */
   color?: Colors[keyof Colors];
+  /** Size value. This value will be used as icon's width and height internally */
+  size?: number;
+  /** Called when a single tap gesture is detected */
+  onPress?: (event: GestureResponderEvent) => void;
 }
 
 export type IconID =

--- a/src/components/__tests__/utils.test.ts
+++ b/src/components/__tests__/utils.test.ts
@@ -1,0 +1,29 @@
+import { getFixedHitSlop } from '../utils';
+
+describe('components/utils', () => {
+  it('getFixedHitSlop', () => {
+    let options = {
+      width: 16,
+      height: 16,
+    };
+    expect(getFixedHitSlop(options)).toEqual({ top: 16, bottom: 16, right: 16, left: 16 });
+
+    options = {
+      width: 48,
+      height: 16,
+    };
+    expect(getFixedHitSlop(options)).toEqual({ top: 16, bottom: 16, right: 0, left: 0 });
+
+    options = {
+      width: 64,
+      height: 16,
+    };
+    expect(getFixedHitSlop(options)).toEqual({ top: 16, bottom: 16, right: 0, left: 0 });
+
+    options = {
+      width: 48,
+      height: 48,
+    };
+    expect(getFixedHitSlop(options)).toEqual(0);
+  });
+});

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -1,0 +1,1 @@
+export const MIN_HIT_SLOP = 48;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,0 +1,3 @@
+import type { Insets } from 'react-native';
+
+export type HitSlop = null | Insets | number;

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,0 +1,16 @@
+import { MIN_HIT_SLOP } from './constants';
+
+export function getFixedHitSlop({ width, height }: { width: number; height: number }) {
+  if (width < MIN_HIT_SLOP || height < MIN_HIT_SLOP) {
+    const horizontalOffset = width < MIN_HIT_SLOP ? (MIN_HIT_SLOP - width) / 2 : 0;
+    const verticalOffset = height < MIN_HIT_SLOP ? (MIN_HIT_SLOP - height) / 2 : 0;
+    const newHitSlop = {
+      top: verticalOffset,
+      bottom: verticalOffset,
+      left: horizontalOffset,
+      right: horizontalOffset,
+    };
+    return newHitSlop;
+  }
+  return 0;
+}


### PR DESCRIPTION
# What
Upgrade onPress prop to icon calculating hit slop when necessary
Add prop size to icon

# Why

To be easier to manipulate and be consistent with design system

# How

Calculating histlop prop based on width and hight props (or size)
converting size prop to width and height

# Sample
<img src="https://user-images.githubusercontent.com/39625749/111368267-698b5780-8674-11eb-8958-185a640441c2.png" width="300" />

# QA

1. Run storybook locally, confirm hitSlop size with icon size lower than 48 and _onPress_ prop
2. Run storybook locally, confirm has no pressable area when icon doesn't have a _onPress_ prop
3. Run storybook locally, confirm icons width and height size when icon has a prop _size_

[AST-57](https://produtomagnetis.atlassian.net/browse/AST-57)
[AST-58](https://produtomagnetis.atlassian.net/browse/AST-58)
[PMF-155](https://produtomagnetis.atlassian.net/browse/PMF-155)
[PMF-156](https://produtomagnetis.atlassian.net/browse/PMF-156)
