### PR TITLE
feat(controls): allow to hide slider label

### DIFF
--- a/src/components/ControlsToggles/Slider.tsx
+++ b/src/components/ControlsToggles/Slider.tsx
@@ -24,6 +24,8 @@ interface SliderProps {
   onValueChange: (newValue: number) => void;
   /** Used to locate this component in end-to-end tests. Defaults to `"Slider"`. */
   testID?: string;
+  /** Hides the label when is needed to display only the slider */
+  hideLabel?: boolean;
 }
 
 /**
@@ -34,6 +36,7 @@ interface SliderProps {
 function Slider({
   disabled = false,
   fullFill = false,
+  hideLabel = false,
   onValueChange,
   label,
   unit = '',
@@ -66,12 +69,14 @@ function Slider({
 
   return (
     <View testID="Slider.Container" style={styles.container}>
-      <View testID="Slider.LabelContainer" style={styles.labelContainer}>
-        <SecondaryTextMedium color={disabled ? colors.moon200 : colors.moon900} bold>
-          {String(slidingValue)} {unitString}
-        </SecondaryTextMedium>
-        <SecondaryTextMedium color={disabled ? colors.moon200 : colors.moon900}>{label}</SecondaryTextMedium>
-      </View>
+      {!hideLabel && (
+        <View testID="Slider.LabelContainer" style={styles.labelContainer}>
+          <SecondaryTextMedium color={disabled ? colors.moon200 : colors.moon900} bold>
+            {String(slidingValue)} {unitString}
+          </SecondaryTextMedium>
+          <SecondaryTextMedium color={disabled ? colors.moon200 : colors.moon900}>{label}</SecondaryTextMedium>
+        </View>
+      )}
       <RNSlider
         {...props}
         {...sliderProps}

--- a/src/components/ControlsToggles/__tests__/Slider.test.tsx
+++ b/src/components/ControlsToggles/__tests__/Slider.test.tsx
@@ -174,4 +174,20 @@ describe('Slider', () => {
     expect(queryByText('1 day')).toBeNull();
     expect(queryByText('6 days')).not.toBeNull();
   });
+
+  it('renders correctly without label', () => {
+    const { queryByText } = render(
+      <Slider
+        unit={{ singular: 'day', plural: 'days' }}
+        hideLabel
+        onValueChange={onValueChange}
+        label="Deadline"
+        minimumValue={1}
+        maximumValue={10}
+      />
+    );
+
+    expect(queryByText('1 day')).toBeNull();
+    expect(queryByText('Deadline')).toBeNull();
+  });
 });

--- a/src/components/ControlsToggles/stories/Slider.story.tsx
+++ b/src/components/ControlsToggles/stories/Slider.story.tsx
@@ -12,6 +12,7 @@ storiesOf('Controls & Toggles', module).add('Slider', () => (
       unit={{ plural: 'days', singular: 'day' }}
       minimumValue={number('minimumValue', 1)}
       maximumValue={number('maximumValue', 70)}
+      hideLabel={boolean('hideLabel', false)}
       fullFill={boolean('fullFill', false)}
       disabled={boolean('disabled', false)}
       onValueChange={(newValue) => console.log('slider to ', newValue)}


### PR DESCRIPTION
# What

Allow to hide slider label

# Why

We need to be able to use only the slider

# How

Create a prop to do this

# Example

<img width="321" alt="Captura de Tela 2021-04-20 às 17 42 38" src="https://user-images.githubusercontent.com/5252760/115461490-deb3f480-a1ff-11eb-9e35-3225c3071fa8.png">


# QA

1. In this branch, go to control and toggles
2. Select the slider and mark the prop hideLabel
3. Verify if there is only the slider been displayed

