### PR TITLE
fix(slider): turns label optional

### DIFF
--- a/src/components/ControlsToggles/Slider.tsx
+++ b/src/components/ControlsToggles/Slider.tsx
@@ -8,12 +8,12 @@ import useDidMount from '@hooks/useDidMount';
 type Unit = string | { singular: string; plural: string };
 
 interface SliderProps {
-  /** Text to be rendered on top of slider */
-  label: string;
   /** Mininum range value */
   minimumValue: number;
   /** Maximum range value */
   maximumValue: number;
+  /** Text to be rendered on top of slider */
+  label?: string;
   /** Disables any user interaction with component. Defaults to `false`. */
   disabled?: boolean;
   /** Unit used for range values. Can be either a single string or an object with `singular` and `plural` keys */
@@ -38,7 +38,7 @@ function Slider({
   fullFill = false,
   hideLabel = false,
   onValueChange,
-  label,
+  label = '',
   unit = '',
   testID = 'Slider',
   ...props
@@ -69,7 +69,7 @@ function Slider({
 
   return (
     <View testID="Slider.Container" style={styles.container}>
-      {!hideLabel && (
+      {!hideLabel && label !== '' && (
         <View testID="Slider.LabelContainer" style={styles.labelContainer}>
           <SecondaryTextMedium color={disabled ? colors.moon200 : colors.moon900} bold>
             {String(slidingValue)} {unitString}

--- a/src/components/ControlsToggles/Slider.tsx
+++ b/src/components/ControlsToggles/Slider.tsx
@@ -24,8 +24,8 @@ interface SliderProps {
   onValueChange: (newValue: number) => void;
   /** Used to locate this component in end-to-end tests. Defaults to `"Slider"`. */
   testID?: string;
-  /** Hides the label when is needed to display only the slider */
-  hideLabel?: boolean;
+  /** Hides the header when is needed to display only the slider */
+  hideHeader?: boolean;
 }
 
 /**
@@ -36,7 +36,7 @@ interface SliderProps {
 function Slider({
   disabled = false,
   fullFill = false,
-  hideLabel = false,
+  hideHeader = false,
   onValueChange,
   label = '',
   unit = '',
@@ -69,12 +69,20 @@ function Slider({
 
   return (
     <View testID="Slider.Container" style={styles.container}>
-      {!hideLabel && label !== '' && (
+      {!hideHeader && (
         <View testID="Slider.LabelContainer" style={styles.labelContainer}>
-          <SecondaryTextMedium color={disabled ? colors.moon200 : colors.moon900} bold>
-            {String(slidingValue)} {unitString}
+          <SecondaryTextMedium
+            accessibilityLabel="valor selecionado"
+            color={disabled ? colors.moon200 : colors.moon900}
+            bold
+          >
+            {`${slidingValue} ${unitString}`}
           </SecondaryTextMedium>
-          <SecondaryTextMedium color={disabled ? colors.moon200 : colors.moon900}>{label}</SecondaryTextMedium>
+          {label !== '' && (
+            <SecondaryTextMedium accessibilityLabel="tipo de valor" color={disabled ? colors.moon200 : colors.moon900}>
+              {label}
+            </SecondaryTextMedium>
+          )}
         </View>
       )}
       <RNSlider

--- a/src/components/ControlsToggles/__tests__/Slider.test.tsx
+++ b/src/components/ControlsToggles/__tests__/Slider.test.tsx
@@ -175,11 +175,11 @@ describe('Slider', () => {
     expect(queryByText('6 days')).not.toBeNull();
   });
 
-  it('renders correctly without label', () => {
+  it('renders correctly without header', () => {
     const { queryByText } = render(
       <Slider
         unit={{ singular: 'day', plural: 'days' }}
-        hideLabel
+        hideHeader
         onValueChange={onValueChange}
         label="Deadline"
         minimumValue={1}
@@ -189,5 +189,19 @@ describe('Slider', () => {
 
     expect(queryByText('1 day')).toBeNull();
     expect(queryByText('Deadline')).toBeNull();
+  });
+
+  it('renders correctly without label', () => {
+    const { getByText, queryByA11yLabel } = render(
+      <Slider
+        unit={{ singular: 'day', plural: 'days' }}
+        onValueChange={onValueChange}
+        minimumValue={1}
+        maximumValue={10}
+      />
+    );
+
+    expect(getByText('1 day')).toBeDefined();
+    expect(queryByA11yLabel('tipo de valor')).toBeNull();
   });
 });

--- a/src/components/ControlsToggles/__tests__/Slider.test.tsx
+++ b/src/components/ControlsToggles/__tests__/Slider.test.tsx
@@ -7,11 +7,11 @@ import { act } from 'react-test-renderer';
 
 const onValueChange = jest.fn();
 
-afterEach(() => {
-  jest.clearAllMocks();
-});
-
 describe('Slider', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders correctly with default props', () => {
     const { getByTestId, getByText } = render(
       <Slider onValueChange={onValueChange} label="Deadline" minimumValue={1} maximumValue={10} />

--- a/src/components/ControlsToggles/stories/Slider.story.tsx
+++ b/src/components/ControlsToggles/stories/Slider.story.tsx
@@ -12,7 +12,7 @@ storiesOf('Controls & Toggles', module).add('Slider', () => (
       unit={{ plural: 'days', singular: 'day' }}
       minimumValue={number('minimumValue', 1)}
       maximumValue={number('maximumValue', 70)}
-      hideLabel={boolean('hideLabel', false)}
+      hideHeader={boolean('hideHeader', false)}
       fullFill={boolean('fullFill', false)}
       disabled={boolean('disabled', false)}
       onValueChange={(newValue) => console.log('slider to ', newValue)}


### PR DESCRIPTION
## What

Turns the slider label optional to be aligned to new prop `hideLabel` added in 6997b0974562193197c2d0ad89e816aabafbd2ba.
Also rename `hideLabel` to `hideHeader`

## Why

To avoid TypeScript errors when slider don't have a label and when prop `hideHeader` is true.

## How

Remove requirement for label prop.

## QA

1. In this branch, go to control and toggles
2. Select the slider and mark the prop hideLabel
3. Don't include prop label
3. Verify if TypeScript doesn't show label related error 