### PR TITLE
[AST-75] add new button colors

### DIFF
--- a/src/components/Buttons/__tests__/utils.test.tsx
+++ b/src/components/Buttons/__tests__/utils.test.tsx
@@ -92,11 +92,15 @@ describe('Button/utils', () => {
     expect(getButtonMainColor('uranus')).toEqual(colors.uranus500);
     expect(getButtonMainColor('mars')).toEqual(colors.mars500);
     expect(getButtonMainColor('earth')).toEqual(colors.earth400);
+    expect(getButtonMainColor('moon')).toEqual(colors.moon600);
+    expect(getButtonMainColor('space')).toEqual(colors.moon100);
 
     expect(getButtonMainColor('venus', { outline: true })).toEqual(colors.venus400);
     expect(getButtonMainColor('uranus', { outline: true })).toEqual(colors.uranus500);
     expect(getButtonMainColor('mars', { outline: true })).toEqual(colors.mars500);
     expect(getButtonMainColor('earth', { outline: true })).toEqual(colors.earth600);
+    expect(getButtonMainColor('moon', { outline: true })).toEqual(colors.moon600);
+    expect(getButtonMainColor('space', { outline: true })).toEqual(colors.moon100);
   });
 
   it('getButtonSecondaryColor', () => {

--- a/src/components/Buttons/types.ts
+++ b/src/components/Buttons/types.ts
@@ -5,7 +5,7 @@ import type { Size } from '@tokens/sizes';
 
 export type ButtonSize = Size;
 
-export type ButtonColor = 'uranus' | 'earth' | 'venus' | 'mars';
+export type ButtonColor = 'uranus' | 'earth' | 'venus' | 'mars' | 'moon' | 'space';
 
 export interface ButtonProps extends PressableProps {
   /** Text to be shown inside the button */

--- a/src/components/Buttons/utils.ts
+++ b/src/components/Buttons/utils.ts
@@ -109,6 +109,10 @@ export function getButtonMainColor(
       return colors.mars500;
     case 'venus':
       return colors.venus400;
+    case 'moon':
+      return colors.moon600;
+    case 'space':
+      return colors.moon100;
     default:
       return colors.uranus500;
   }


### PR DESCRIPTION
# What

Add `moon` and `space` colors

# Why

Broaden the range of color possibilities

# How

- Add `moon` (moon600) and `space` (moon100) colors

# Sample

![image](https://user-images.githubusercontent.com/13890272/117055160-3a4aab80-acf1-11eb-8fde-cad34bfd1156.png)

# QA

The unity test `src/components/Button/__tests__/utils` is enough to test this change

[AST-75](https://produtomagnetis.atlassian.net/browse/AST-75)
