### PR TITLE
feat(controlstoggles/selection): add selection component

### DIFF
--- a/src/components/ControlsToggles/Selection.tsx
+++ b/src/components/ControlsToggles/Selection.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Colors, colors } from '@magnetis/astro-galaxy-tokens';
+
+import { IconID } from '@components/Icons/types';
+import useDidMount from '@hooks/useDidMount';
+import sizes from '@tokens/sizes';
+import { getSecondaryTextFromSize } from '@components/Text/utils';
+import { getIcon } from '@components/Buttons/utils';
+import { getFontSize } from '@tokens/utils';
+import type { Size } from '@tokens/sizes';
+
+interface SelectionItem {
+  /** Text to be shown inside selection */
+  label: string;
+  /** Value that will be returned when selection is selected */
+  value: string;
+  /** When provided, shows Icon aside selection text. */
+  icon?: IconID;
+  /** Disables any user interaction with component. Defaults to `false`. */
+  disabled?: boolean;
+  /** Items' backgroundColor color when active */
+  activeColor?: Colors[keyof Colors];
+  /** Items' text color when active */
+  activeTextColor?: Colors[keyof Colors];
+}
+
+interface SelectionProps {
+  /** List of selection items */
+  items: SelectionItem[];
+  /** Items' text color when not active */
+  textColor: Colors[keyof Colors];
+  /** Items' text color when disabled */
+  disabledColor: Colors[keyof Colors];
+  /** Items' text color when active */
+  activeTextColor: Colors[keyof Colors];
+  /** Items' backgroundColor color when active */
+  activeItemColor?: Colors[keyof Colors] | 'transparent';
+  /** Items' backgroundColor color when not active */
+  backgroundColor?: Colors[keyof Colors] | 'transparent';
+  /** Used to locate this component in end-to-end tests. Defaults to `"Selection"`. */
+  testID?: string;
+  /** Disables any user interaction with component. Defaults to `false`. */
+  disabled?: boolean;
+  /** Define which size selection will have. Defaults to `"medium"`. */
+  size?: Size;
+  /** Selection border color */
+  borderColor?: Colors[keyof Colors] | 'transparent';
+  /** Callback called when a selection is selected */
+  onChange: (value: string) => void;
+  /** When provided, defines which selection will be selected at first */
+  defaultSelected?: string;
+}
+
+/**
+ * Selection are used when the user wants to select and item in a short list.
+ */
+function Selection({
+  disabled = false,
+  activeItemColor = colors.uranus500,
+  activeTextColor,
+  backgroundColor = colors.moon100,
+  defaultSelected,
+  disabledColor,
+  textColor = colors.uranus500,
+  onChange,
+  items,
+  borderColor = colors.uranus500,
+  size = sizes.Medium,
+  testID = 'Selection',
+}: SelectionProps) {
+  const didMount = useDidMount();
+  const TextComponent = getSecondaryTextFromSize(size);
+  const [selectedItem, setSelectedItem] = useState(defaultSelected || items[0].value);
+
+  function handlePress(value: string) {
+    return function () {
+      if (value !== selectedItem) {
+        setSelectedItem(value);
+      }
+    };
+  }
+
+  useEffect(() => {
+    if (didMount) {
+      onChange(selectedItem);
+    }
+  }, [selectedItem]);
+
+  return (
+    <View testID={testID} style={styles.container}>
+      {items.map((item) => {
+        const Icon = getIcon(item.icon ?? '');
+        const active = selectedItem === item.value;
+        const itemBackgroundColor =
+          item.disabled || disabled ? colors.moon100 : active ? item.activeColor ?? activeItemColor : backgroundColor;
+        const color =
+          item.disabled || disabled ? disabledColor : active ? item.activeTextColor ?? activeTextColor : textColor;
+        const iconSize = getFontSize(size) * 1.5;
+        const borderWidth = active ? 0 : 1;
+        const itemBorderColor = item.disabled || disabled ? disabledColor : borderColor;
+
+        return (
+          <Pressable
+            testID={`${testID}.Item.Pressable-${item.value}`}
+            key={item.value}
+            style={[
+              styles.item,
+              {
+                backgroundColor: itemBackgroundColor,
+                borderColor: itemBorderColor,
+                borderWidth,
+                paddingHorizontal: iconSize,
+              },
+            ]}
+            onPress={handlePress(item.value)}
+            disabled={item.disabled || disabled}
+          >
+            <Icon testID={`Selection.Item.Icon-${item.value}`} color={color} width={iconSize} height={iconSize} />
+            <TextComponent style={{ marginLeft: item.icon ? 8 : 0 }} color={color}>
+              {item.label}
+            </TextComponent>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { width: '100%', flex: 0, padding: 4 },
+  item: {
+    alignItems: 'center',
+    borderRadius: 8,
+    flex: 0,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginVertical: 10,
+    minWidth: '80%',
+    paddingVertical: 8,
+  },
+  itemWithBorderBottom: {
+    borderBottomWidth: 2,
+    borderRadius: 0,
+    paddingBottom: 12,
+    paddingVertical: 0,
+  },
+});
+
+export default Selection;
+export type { SelectionProps, SelectionItem };

--- a/src/components/ControlsToggles/__tests__/Selection.test.tsx
+++ b/src/components/ControlsToggles/__tests__/Selection.test.tsx
@@ -1,0 +1,461 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { colors } from '@magnetis/astro-galaxy-tokens';
+
+import Selection, { SelectionItem } from '../Selection';
+
+afterEach(() => jest.clearAllMocks());
+
+const items: SelectionItem[] = [
+  { label: 'Item #1', value: 'item-1', icon: 'Cake' },
+  { label: 'Item #2', value: 'item-2', activeColor: colors.mars500, activeTextColor: colors.space700 },
+  { label: 'Item #3', value: 'item-3', disabled: true },
+  { label: 'Item #4', value: 'item-4', activeColor: colors.venus500 },
+  { label: 'Item #5', value: 'item-5', activeTextColor: colors.earth500 },
+  { label: 'Item #6', value: 'item-6' },
+];
+
+const onChange = jest.fn();
+
+const props = {
+  items,
+  onChange,
+  backgroundColor: colors.space100,
+  textColor: colors.moon900,
+  activeItemColor: colors.uranus500,
+  activeTextColor: colors.space100,
+  disabledColor: colors.moon200,
+};
+
+describe('Selection', () => {
+  it('renders correctly with default props', () => {
+    const { getByTestId, getByText } = render(<Selection {...props} />);
+
+    // Check Container styles
+    expect(getByTestId('Selection').props.style).toEqual(
+      expect.objectContaining({
+        width: '100%',
+        flex: 0,
+        padding: 4,
+      })
+    );
+
+    // Check Pressable styles
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[0]).toEqual(
+      expect.objectContaining({
+        alignItems: 'center',
+        borderRadius: 8,
+        flex: 0,
+        flexDirection: 'row',
+        justifyContent: 'center',
+        marginVertical: 10,
+        minWidth: '80%',
+        paddingVertical: 8,
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.uranus500,
+        paddingHorizontal: 16 * 1.5,
+      })
+    );
+    expect(getByText('Item #1').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.space100,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-2').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.space100,
+      })
+    );
+    expect(getByText('Item #2').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon900,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-3').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.moon100,
+      })
+    );
+    expect(getByText('Item #3').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon200,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-4').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.space100,
+      })
+    );
+    expect(getByText('Item #4').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon900,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-5').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.space100,
+      })
+    );
+    expect(getByText('Item #5').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon900,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-6').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.space100,
+      })
+    );
+    expect(getByText('Item #6').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon900,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+  });
+
+  it('renders correctly when backgroundColor and activeItemColor are not passed', () => {
+    const { getByTestId, getByText } = render(
+      <Selection
+        items={props.items}
+        onChange={props.onChange}
+        textColor={props.textColor}
+        activeTextColor={props.activeTextColor}
+        disabledColor={props.disabledColor}
+      />
+    );
+
+    // Check container styles
+    expect(getByTestId('Selection').props.style).toEqual(
+      expect.objectContaining({
+        width: '100%',
+        flex: 0,
+        padding: 4,
+      })
+    );
+
+    // Check Pressable styles
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[0]).toEqual(
+      expect.objectContaining({
+        minWidth: '80%',
+        marginVertical: 10,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 0,
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.uranus500,
+        paddingHorizontal: 24,
+      })
+    );
+    expect(getByText('Item #1').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.space100,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+  });
+
+  it('renders icon aside when option has it', () => {
+    const { queryByTestId } = render(<Selection {...props} />);
+
+    expect(queryByTestId('Selection.Item.Icon-item-1')).not.toBeNull();
+  });
+
+  it('changes color of active items', () => {
+    const { getByTestId, getByText } = render(<Selection {...props} />);
+
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.uranus500,
+      })
+    );
+    expect(getByText('Item #1').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.space100,
+      })
+    );
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-2'));
+    expect(getByTestId('Selection.Item.Pressable-item-2').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.mars500,
+      })
+    );
+    expect(getByText('Item #2').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.space700,
+      })
+    );
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-3'));
+    expect(getByTestId('Selection.Item.Pressable-item-3').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.moon100,
+      })
+    );
+    expect(getByText('Item #3').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon200,
+      })
+    );
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-4'));
+    expect(getByTestId('Selection.Item.Pressable-item-4').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.venus500,
+      })
+    );
+    expect(getByText('Item #4').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.space100,
+      })
+    );
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-5'));
+    expect(getByTestId('Selection.Item.Pressable-item-5').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.uranus500,
+      })
+    );
+    expect(getByText('Item #5').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.earth500,
+      })
+    );
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-6'));
+    expect(getByTestId('Selection.Item.Pressable-item-6').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.uranus500,
+      })
+    );
+    expect(getByText('Item #6').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.space100,
+      })
+    );
+  });
+
+  it('renders correctly in every size', () => {
+    const { getByTestId, getByText, update } = render(<Selection size="very-small" {...props} />);
+
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        paddingHorizontal: 12 * 1.5,
+      })
+    );
+    expect(getByText('Item #1').props.style).toEqual(
+      expect.objectContaining({
+        fontSize: 12,
+      })
+    );
+    expect(getByTestId('Selection.Item.Icon-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        width: 12 * 1.5,
+        height: 12 * 1.5,
+      })
+    );
+
+    update(<Selection {...props} size="small" />);
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        paddingHorizontal: 14 * 1.5,
+      })
+    );
+    expect(getByText('Item #1').props.style).toEqual(
+      expect.objectContaining({
+        fontSize: 14,
+      })
+    );
+    expect(getByTestId('Selection.Item.Icon-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        width: 14 * 1.5,
+        height: 14 * 1.5,
+      })
+    );
+
+    update(<Selection {...props} size="medium" />);
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        paddingHorizontal: 16 * 1.5,
+      })
+    );
+    expect(getByText('Item #1').props.style).toEqual(
+      expect.objectContaining({
+        fontSize: 16,
+      })
+    );
+    expect(getByTestId('Selection.Item.Icon-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        width: 16 * 1.5,
+        height: 16 * 1.5,
+      })
+    );
+
+    update(<Selection {...props} size="large" />);
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        paddingHorizontal: 24 * 1.5,
+      })
+    );
+    expect(getByText('Item #1').props.style).toEqual(
+      expect.objectContaining({
+        fontSize: 24,
+      })
+    );
+    expect(getByTestId('Selection.Item.Icon-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        width: 24 * 1.5,
+        height: 24 * 1.5,
+      })
+    );
+  });
+
+  it('renders correctly when disabled is true', () => {
+    const { getByTestId, getByText } = render(<Selection disabled {...props} />);
+
+    // Check ScrolView styles
+    expect(getByTestId('Selection').props.style).toEqual(
+      expect.objectContaining({
+        width: '100%',
+        flex: 0,
+        padding: 4,
+      })
+    );
+
+    // Check Pressable styles
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[0]).toEqual(
+      expect.objectContaining({
+        minWidth: '80%',
+        marginVertical: 10,
+        paddingVertical: 8,
+        borderRadius: 8,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 0,
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-1').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.moon100,
+        paddingHorizontal: 16 * 1.5,
+      })
+    );
+    expect(getByText('Item #1').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon200,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-2').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.moon100,
+      })
+    );
+    expect(getByText('Item #2').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon200,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-3').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.moon100,
+      })
+    );
+    expect(getByText('Item #3').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon200,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-4').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.moon100,
+      })
+    );
+    expect(getByText('Item #4').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon200,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-5').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.moon100,
+      })
+    );
+    expect(getByText('Item #5').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon200,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+
+    expect(getByTestId('Selection.Item.Pressable-item-6').props.style[1]).toEqual(
+      expect.objectContaining({
+        backgroundColor: colors.moon100,
+      })
+    );
+    expect(getByText('Item #6').props.style).toEqual(
+      expect.objectContaining({
+        color: colors.moon200,
+        fontFamily: 'Lato-Regular',
+      })
+    );
+  });
+
+  it('does not call onChange if item is already selected', () => {
+    const { getByTestId } = render(<Selection {...props} />);
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-1'));
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not call onChange if item is disabled', () => {
+    const { getByTestId } = render(<Selection {...props} />);
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-3'));
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not call onChange when tab is disabled', () => {
+    const { getByTestId } = render(<Selection disabled {...props} />);
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-3'));
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('calls onChange with pressed item value', () => {
+    const { getByTestId } = render(<Selection {...props} />);
+
+    fireEvent.press(getByTestId('Selection.Item.Pressable-item-2'));
+    expect(onChange).toHaveBeenCalledWith('item-2');
+  });
+});

--- a/src/components/ControlsToggles/index.ts
+++ b/src/components/ControlsToggles/index.ts
@@ -3,6 +3,7 @@ export { default as Radio } from './Radio';
 export { default as RadioGroup } from './RadioGroup';
 export { default as Checkbox } from './Checkbox';
 export { default as Slider } from './Slider';
+export { default as Selection } from './Selection';
 export { default as Tabs } from './Tabs';
 
 export type { ToggleProps } from './Toggle';
@@ -10,4 +11,5 @@ export type { RadioProps } from './Radio';
 export type { RadioGroupProps } from './RadioGroup';
 export type { CheckboxProps } from './Checkbox';
 export type { SliderProps } from './Slider';
+export type { SelectionProps, SelectionItem } from './Selection';
 export type { TabsProps, TabItem } from './Tabs';

--- a/src/components/ControlsToggles/stories/Selection.story.tsx
+++ b/src/components/ControlsToggles/stories/Selection.story.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import { boolean, select } from '@storybook/addon-knobs';
+import { Colors, colors } from '@magnetis/astro-galaxy-tokens';
+
+import sizes from '@tokens/sizes';
+import { Selection } from '..';
+import { colorOptions, colorOptionsWithTransparent, sizeOptions } from '@root/storybook/options';
+import type { SelectionItem } from '..';
+
+const items: SelectionItem[] = [
+  { label: 'Item #1', icon: 'Cake', value: 'item-1' },
+  { label: 'Item #2', value: 'item-2' },
+  { label: 'Item #3', value: 'item-3', disabled: true },
+  { label: 'Item #4', value: 'item-4' },
+  { label: 'Item #5', value: 'item-5' },
+  { label: 'Item #6', value: 'item-6' },
+];
+
+const controlsTogglesStories = storiesOf('Controls & Toggles', module);
+
+controlsTogglesStories.add('Selection', () => (
+  <View style={{ width: '100%', flex: 1, justifyContent: 'center' }}>
+    <View style={{ width: '100%' }}>
+      <Selection
+        onChange={(value: string) => console.log('Tab selected ->', value)}
+        items={items}
+        disabled={boolean('disabled', false)}
+        defaultSelected="item-2"
+        borderColor={select('borderColor', colorOptionsWithTransparent, colors.uranus500)}
+        textColor={select('textColor', colorOptionsWithTransparent, colors.uranus500) as Colors[keyof Colors]}
+        disabledColor={select('disabledColor', colorOptions, colors.moon600)}
+        activeTextColor={select('activeTextColor', colorOptionsWithTransparent, colors.moon100) as Colors[keyof Colors]}
+        size={select('size', sizeOptions, sizes.Medium)}
+      />
+    </View>
+  </View>
+));
+
+controlsTogglesStories.add('Selection with borderBottom', () => (
+  <View style={{ width: '100%', flex: 1, justifyContent: 'center' }}>
+    <View style={{ width: '100%' }}>
+      <Selection
+        onChange={(value: string) => console.log('Tab selected ->', value)}
+        items={items}
+        disabled={boolean('disabled', false)}
+        defaultSelected="item-1"
+        textColor={select('textColor', colorOptionsWithTransparent, colors.moon300) as Colors[keyof Colors]}
+        disabledColor={select('disabledColor', colorOptions, colors.moon200)}
+        activeTextColor={
+          select('activeTextColor', colorOptionsWithTransparent, colors.uranus500) as Colors[keyof Colors]
+        }
+        size={select('size', sizeOptions, sizes.Medium)}
+      />
+    </View>
+  </View>
+));
+
+export {};

--- a/src/components/ControlsToggles/stories/index.ts
+++ b/src/components/ControlsToggles/stories/index.ts
@@ -2,5 +2,6 @@ import './Checkbox.story';
 import './Radio.story';
 import './RadioGroup.story';
 import './Slider.story';
+import './Selection.story';
 import './Tabs.story';
 import './Toggle.story';


### PR DESCRIPTION
# What

Add `Selection` component

# Why

Improve components base with a component that make easily select and option in a short list

# How

- Create `Selection` component [`src/components/ControlsToggles/Selection`]
- Add story of component

# Sample

<img src="https://user-images.githubusercontent.com/13890272/117074095-45a9d100-ad09-11eb-8bd7-61066af47c1c.gif" height="520" width="250" />

# QA
 
Open storybook locally > Open ControlsToggles components list > Select `Selection` component

[AST-50](https://produtomagnetis.atlassian.net/browse/AST-50)
