### PR TITLE
chore(TextInput): change component composition

### DIFF
--- a/src/components/Inputs/InputLabel.tsx
+++ b/src/components/Inputs/InputLabel.tsx
@@ -41,7 +41,7 @@ function InputLabel({
     () => ({
       backgroundColor: getInputBackgroundColor({ disabled }),
       top: large ? -8 : -6,
-      paddingLeft: baseSize,
+      left: baseSize,
     }),
     [large, disabled, baseSize]
   );
@@ -60,6 +60,7 @@ function InputLabel({
   return (
     <Animated.View
       testID="InputLabel"
+      pointerEvents="none"
       style={[styles.labelContainer, { transform: [{ translateY: labelAnim }] }, computedLabelContainerStyles]}
     >
       <Text numberOfLines={1} style={[styles.label, computedTextStyles]}>
@@ -73,10 +74,7 @@ const styles = StyleSheet.create({
   labelContainer: {
     position: 'absolute',
     overflow: 'hidden',
-    zIndex: 1,
     left: 0,
-    width: '100%',
-    borderRadius: 8,
     paddingTop: 8,
     paddingBottom: 4,
   },

--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { TextInput as RNTextInput, Pressable, StyleSheet, View } from 'react-native';
+import { TextInput as RNTextInput, StyleSheet, View } from 'react-native';
 
 import { getInputBackgroundColor, getInputBorderColor } from './utils';
 import type { BaseInputProps } from './types';
@@ -61,10 +61,6 @@ function TextInput({
     }
   }, [props.value]);
 
-  function handleInputPress() {
-    inputRef.current?.focus();
-  }
-
   function handleInputFocus() {
     setHasFocus(true);
     onFocus && onFocus();
@@ -88,11 +84,7 @@ function TextInput({
 
   return (
     <View testID="TextInput" style={styles.wrapper}>
-      <Pressable
-        testID="TextInput.Container"
-        onPress={handleInputPress}
-        style={[styles.container, computedContainerStyles]}
-      >
+      <View testID="TextInput.Container" style={[styles.container, computedContainerStyles]}>
         <InputLabel
           hasFocus={hasFocus}
           disabled={disabled}
@@ -115,7 +107,7 @@ function TextInput({
           onChangeText={handleOnChangeText}
         />
         {!password && <InputStatusIcon hasError={hasError} isValidated={isValidated} large={large} />}
-      </Pressable>
+      </View>
       {password && (
         <InputEyeToggle
           hasError={hasError}
@@ -135,11 +127,16 @@ const styles = StyleSheet.create({
   container: {
     borderWidth: 1,
     borderRadius: 8,
+    paddingTop: 0,
+    paddingBottom: 0,
   },
   input: {
     fontFamily: lato,
     paddingBottom: 8,
     paddingTop: 28,
+    flexGrow: 1,
+    margin: 0,
+    zIndex: 1,
   },
 });
 

--- a/src/components/Inputs/__tests__/InputLabel.test.tsx
+++ b/src/components/Inputs/__tests__/InputLabel.test.tsx
@@ -31,17 +31,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -68,17 +64,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#f6f7f8',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -105,17 +97,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -142,17 +130,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -179,17 +163,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 16 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -217,17 +197,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 24,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 24,
         paddingTop: 8,
         position: 'absolute',
         top: -8,
         transform: [{ translateY: 8 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -255,17 +231,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#f6f7f8',
-        borderRadius: 8,
-        left: 0,
+        left: 24,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 24,
         paddingTop: 8,
         position: 'absolute',
         top: -8,
         transform: [{ translateY: 8 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -293,17 +265,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 24,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 24,
         paddingTop: 8,
         position: 'absolute',
         top: -8,
         transform: [{ translateY: 8 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -331,17 +299,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 24,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 24,
         paddingTop: 8,
         position: 'absolute',
         top: -8,
         transform: [{ translateY: 8 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -369,17 +333,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 24,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 24,
         paddingTop: 8,
         position: 'absolute',
         top: -8,
         transform: [{ translateY: 18 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[0]).toEqual(expect.objectContaining({ fontFamily: 'Lato-Bold' }));
@@ -406,17 +366,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 16 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[1]).toEqual(
@@ -435,17 +391,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[1]).toEqual(
@@ -472,17 +424,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 24,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 24,
         paddingTop: 8,
         position: 'absolute',
         top: -8,
         transform: [{ translateY: 18 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[1]).toEqual(
@@ -499,17 +447,13 @@ describe('InputLabel', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -8,
         transform: [{ translateY: 8 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
     expect(getByText('Label').props.style[1]).toEqual(

--- a/src/components/Inputs/__tests__/TextAreaInput.test.tsx
+++ b/src/components/Inputs/__tests__/TextAreaInput.test.tsx
@@ -56,17 +56,13 @@ describe('TextAreaInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 16 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -106,17 +102,13 @@ describe('TextAreaInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -156,17 +148,13 @@ describe('TextAreaInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 16 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
 
@@ -176,17 +164,13 @@ describe('TextAreaInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -224,17 +208,13 @@ describe('TextAreaInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -274,17 +254,13 @@ describe('TextAreaInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });

--- a/src/components/Inputs/__tests__/TextInput.test.tsx
+++ b/src/components/Inputs/__tests__/TextInput.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { act, create } from 'react-test-renderer';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act } from 'react-test-renderer';
+import { fireEvent, render } from '@testing-library/react-native';
 
 import TextInput from '../TextInput';
 import { colors } from '@magnetis/astro-galaxy-tokens';
@@ -56,17 +56,13 @@ describe('TextInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 16 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -106,17 +102,13 @@ describe('TextInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -156,17 +148,13 @@ describe('TextInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 16 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
 
@@ -176,17 +164,13 @@ describe('TextInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -224,17 +208,13 @@ describe('TextInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -274,17 +254,13 @@ describe('TextInput', () => {
     expect(getByTestId('InputLabel').props.style).toEqual(
       expect.objectContaining({
         backgroundColor: '#ffffff',
-        borderRadius: 8,
-        left: 0,
+        left: 16,
         overflow: 'hidden',
         paddingBottom: 4,
-        paddingLeft: 16,
         paddingTop: 8,
         position: 'absolute',
         top: -6,
         transform: [{ translateY: 6 }],
-        width: '100%',
-        zIndex: 1,
       })
     );
   });
@@ -495,15 +471,5 @@ describe('TextInput', () => {
     expect(getByTestId('TextInput.Container').props.style[1]).toEqual(
       expect.objectContaining({ backgroundColor: colors.space100, borderColor: colors.moon900 })
     );
-  });
-
-  it('focus input when container is pressed', async () => {
-    const wrapper = create(<TextInput {...props} touched={false} />);
-    const container = wrapper.root.findByProps({ testID: 'TextInput.Container' });
-    const input = wrapper.root.findByProps({ testID: 'TextInput.Input' });
-    const spy = jest.spyOn(input.instance, 'focus');
-
-    fireEvent.press(container);
-    waitFor(() => expect(spy).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
# What

The current `TextInput` component layout obfuscates accessibility attributes. In e2e tests especially [XCUITest](https://appium.io/docs/en/drivers/ios-xcuitest/) in iOS can not locate pressable and touchables elements. 

Changing some properties and component layout of `TextInput` and `InputLabel` solves the problem without change any Astro visual style to these components.

# Why

e2e frameworks like Appium renders a tree of elements that represents native components. When a component enables `accessible` property  in React Native side any child element is hidden in generated tree of Appium. This breaks any test that needs to find this specific element.

The solution here only changes the component composition and do not change the `accessible` prop because is not necessary.

In this case of Astro's `TextInput` we don't need a `Pressable` as parent of the TextInput. The pressable is been using to detect when user press any of the children and when this happens it should focus `Textinput`. I understand the reason behind that since `InputLabel` can block user touch actions which is totally plausible. But we can solve this by simple adding [`pointerEvents="none"`](https://reactnative.dev/docs/view#pointerevents) in InputLabel `Animated.View` that ignores any touch actions.


# Sample

![input-changes](https://user-images.githubusercontent.com/3925418/118493978-0d869300-b6f8-11eb-9f87-c23573661774.gif)


[UPR-1144](https://produtomagnetis.atlassian.net/browse/UPR-1144)

