### PR TITLE
Disable onPress event when loading is true

### DIFF
--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -68,7 +68,7 @@ function BaseButton({
 
   const pressableProps = {
     onPress: props.onPress,
-    disabled: disabled,
+    disabled: disabled || loading,
     style: [styles.button, computedStyles],
     testID: props.testID,
     hitSlop: typeof props.hitSlop !== 'undefined' ? props.hitSlop : hitSlop,

--- a/src/components/Buttons/__tests__/BaseButton.test.tsx
+++ b/src/components/Buttons/__tests__/BaseButton.test.tsx
@@ -58,6 +58,18 @@ describe('BaseButton', () => {
     expect(onPress).toHaveBeenCalledTimes(0);
   });
 
+  it('has no interaction when loading is true', () => {
+    const { getByTestId } = render(
+      <BaseButton {...props} loading>
+        <ButtonText />
+      </BaseButton>
+    );
+    const baseButton = getByTestId('BaseButton');
+
+    fireEvent.press(baseButton);
+    expect(onPress).toHaveBeenCalledTimes(0);
+  });
+
   it('renders correctly when loading is true', () => {
     const { getByTestId } = render(
       <BaseButton {...props} loading>

--- a/src/components/Buttons/__tests__/BaseButton.test.tsx
+++ b/src/components/Buttons/__tests__/BaseButton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { fireEvent, render, act } from '@testing-library/react-native';
+import { render, act } from '@testing-library/react-native';
 import { colors } from '@magnetis/astro-galaxy-tokens';
 
 import BaseButton from '../BaseButton';
@@ -52,10 +52,8 @@ describe('BaseButton', () => {
         <ButtonText />
       </BaseButton>
     );
-    const baseButton = getByTestId('BaseButton');
 
-    fireEvent.press(baseButton);
-    expect(onPress).toHaveBeenCalledTimes(0);
+    expect(getByTestId('BaseButton')).toBeDisabled();
   });
 
   it('has no interaction when loading is true', () => {
@@ -64,10 +62,8 @@ describe('BaseButton', () => {
         <ButtonText />
       </BaseButton>
     );
-    const baseButton = getByTestId('BaseButton');
 
-    fireEvent.press(baseButton);
-    expect(onPress).toHaveBeenCalledTimes(0);
+    expect(getByTestId('BaseButton')).toBeDisabled();
   });
 
   it('renders correctly when loading is true', () => {


### PR DESCRIPTION

# What
When a button is loading, it should not be able to press it and trigger onPress event


# Why
Because loading state means that we are waiting for something before button interaction is avaliable.

# How

<!-- Describe the rationale for the changes introduced on this PR -->
Adding loading prop on disabled state of BaseButton.

# Sample
N/A

# QA
1. Open any type of button;
2. Change loading prop to true;
3. Check that onPress event is no longer triggered;
