### PR TITLE
release: bump version to v1.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.8.7](https://github.com/magnetis/astro-native/compare/v1.8.6...v1.8.7) (2021-10-07)
+
+
+### Bug Fixes
+
+* **basebutton:** disable onPress event when loading is true ([798d2c1](https://github.com/magnetis/astro-native/commit/798d2c1989d8ef58b8ff0cf9bac35cc50813322d))
+
+
+### Features
+
+* **icons:** add icons ([690d9fb](https://github.com/magnetis/astro-native/commit/690d9fbd4bea8200c1141a17d315994ee5c8cc90))
+
+
+
 ## [1.8.6](https://github.com/magnetis/astro-native/compare/v1.8.5...v1.8.6) (2021-06-25)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-native",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Astro components for React Native",
   "homepage": "https://astro-galaxy.magnetis.com.br/",
   "files": [


### PR DESCRIPTION
## [1.8.7](https://github.com/magnetis/astro-native/compare/v1.8.6...v1.8.7) (2021-10-07)


### Bug Fixes

* **basebutton:** disable onPress event when loading is true ([798d2c1](https://github.com/magnetis/astro-native/commit/798d2c1989d8ef58b8ff0cf9bac35cc50813322d))

