### PR TITLE
feat(tabs): add rounded prop

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -7,6 +7,7 @@ export interface TabProps extends PressableProps {
   value: string;
   activeItem: boolean;
   inversed?: boolean;
+  rounded?: boolean;
 }
 
 function handleTextColor(activeItem: boolean, inversed?: boolean) {
@@ -17,7 +18,7 @@ function handleTextColor(activeItem: boolean, inversed?: boolean) {
   return colors.transparentBrightDiffuse;
 }
 
-function Tab({ value, activeItem, inversed, ...props }: TabProps) {
+function Tab({ value, activeItem, inversed, rounded, ...props }: TabProps) {
   return (
     <Pressable
       {...props}
@@ -25,6 +26,7 @@ function Tab({ value, activeItem, inversed, ...props }: TabProps) {
         styles.container,
         {
           backgroundColor: activeItem ? colors.solidBrightLightest : 'transparent',
+          borderRadius: rounded ? radius.circular : radius.small,
         },
         {
           ...(activeItem && {
@@ -59,7 +61,6 @@ const styles = StyleSheet.create({
     height: sizes.large,
     justifyContent: 'center',
     alignItems: 'center',
-    borderRadius: radius.small,
   },
 });
 

--- a/src/components/Tabs/TabsContainer.tsx
+++ b/src/components/Tabs/TabsContainer.tsx
@@ -12,9 +12,10 @@ type Item = {
 export interface TabsContainerProps extends PressableProps {
   items: Item[];
   inversed?: boolean;
+  rounded?: boolean;
 }
 
-function TabsContainer({ testID, items, inversed, ...props }: TabsContainerProps) {
+function TabsContainer({ testID, items, inversed, rounded, ...props }: TabsContainerProps) {
   const [activeItem, setActiveItem] = useState(0);
 
   return (
@@ -24,12 +25,14 @@ function TabsContainer({ testID, items, inversed, ...props }: TabsContainerProps
         styles.tabsContainer,
         {
           backgroundColor: inversed ? colors.transparentBrightSemitransparent : colors.transparentFaintSemitransparent,
+          borderRadius: rounded ? radius.circular : radius.small,
         },
       ]}
     >
       {items.map((item, index) => (
         <Tab
           {...props}
+          rounded={rounded}
           testID={`Tab.${item.value}`}
           key={item.value}
           value={item.value}
@@ -50,7 +53,6 @@ const styles = StyleSheet.create({
     width: '100%',
     flexDirection: 'row',
     padding: sizes.quark,
-    borderRadius: radius.small,
   },
 });
 

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,0 +1,2 @@
+export { default as Tabs } from './TabsContainer';
+export type { TabsContainerProps } from './TabsContainer';

--- a/src/components/Tabs/stories/TabsContainer.story.tsx
+++ b/src/components/Tabs/stories/TabsContainer.story.tsx
@@ -35,7 +35,12 @@ storiesOf('Tabs', module).add('TabsContainer', () => (
         },
       ]}
     >
-      <TabsContainer items={TWO_ITEMS} inversed={boolean('inversed', true)} onPress={() => console.log('value')} />
+      <TabsContainer
+        items={TWO_ITEMS}
+        inversed={boolean('inversed', true)}
+        rounded
+        onPress={() => console.log('value')}
+      />
     </View>
     <View style={[styles.container, { marginTop: sizes.mini }]}>
       <TabsContainer items={THREE_ITEMS} />

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ export type { ButtonProps } from '@components/Buttons';
 export * from '@components/ButtonsGroup';
 export type { ButtonsGroupProps } from '@components/ButtonsGroup';
 
+// TabsContainer
+export * from '@components/Tabs';
+export type { TabsContainerProps } from '@components/Tabs';
+
 // Icons
 export * from '@components/Icons';
 export type { IconProps } from '@components/Icons';


### PR DESCRIPTION
# What

Add  rounded prop to render tabs with legacy layout

# Why

Turn the UI breaking change soft, changing the tab format

# How

- Add `rounded` prop to render `circular` border radius

# Sample
|Tabs |
| ------------- |
| https://user-images.githubusercontent.com/39625749/140752819-3c6884e6-220c-4e12-b103-97145e6083bd.png 

# QA

Select the tabs and check the border radius of tabs needs to turn rounded.

<!-- ✅ TODOs -->
<!-- Assign at least one manteiner to review this PR -->
<!-- Assign everyone who worked on this PR -->

<!-- EXTRAS -->
<!-- 💸 Describe possible tech debits -->
<!-- Jira link if needed -->