### PR TITLE
Feature/legacy buttons group

### DIFF
--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -1,11 +1,9 @@
 import React, { useCallback, useState } from 'react';
 import { View, StyleSheet, ActivityIndicator, Pressable, PressableProps, LayoutChangeEvent } from 'react-native';
 
-import { borders } from '@magnetis/astro-tokens';
-
 import { getFixedHitSlop } from '@components/utils';
 
-import { getButtonPadding, getLoadingSize } from '@components/Buttons/utils';
+import { getButtonHeight, getButtonHorizontalPadding, getLoadingSize } from '@components/Buttons/utils';
 
 import type { HitSlop, Size } from '@components/types';
 
@@ -25,7 +23,6 @@ const styles = StyleSheet.create({
   button: {
     alignItems: 'center',
     alignSelf: 'stretch',
-    borderWidth: borders.hairline,
     flexDirection: 'row',
     justifyContent: 'center',
   },
@@ -38,15 +35,16 @@ function BaseButton({
   activityIndicatorColor,
   children,
   fill = false,
-  isIconButton = false,
   loading = false,
   size = 'medium',
+  isIconButton = false,
   ...props
 }: BaseButtonProps) {
   const [hitSlop, setHitSlop] = useState<HitSlop>({ top: 0, bottom: 0, left: 0, right: 0 });
 
   const computedStyles: any = {
-    ...getButtonPadding(size, { isIconButton }),
+    ...getButtonHeight(size),
+    ...getButtonHorizontalPadding(size, { isIconButton }),
     backgroundColor: props.backgroundColor,
     borderColor: props.borderColor,
     borderRadius: props.borderRadius,

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -33,7 +33,8 @@ function Button({
   const baseProps = {
     activityIndicatorColor: textColor,
     backgroundColor,
-    borderColor: type === 'outline' ? textColor : backgroundColor,
+    borderColor: type === 'outline' ? textColor : 'transparent',
+    borderWidth: type === 'outline' ? 1 : 0,
     borderRadius: rounded ? radius.circular : radius.small,
     disabled,
     textColor,

--- a/src/components/Buttons/__tests__/BaseButton.test.tsx
+++ b/src/components/Buttons/__tests__/BaseButton.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text } from 'react-native';
 import { fireEvent, render, act } from '@testing-library/react-native';
-import { borders, colors, radius, sizes } from '@magnetis/astro-tokens';
+import { colors, radius, sizes } from '@magnetis/astro-tokens';
 
 import BaseButton from '../BaseButton';
 
@@ -36,8 +36,6 @@ describe('BaseButton', () => {
       backgroundColor: colors.solidPrimaryMedium,
       borderColor: colors.solidPrimaryMedium,
       borderRadius: radius.small,
-      borderWidth: borders.hairline,
-      paddingVertical: 17,
       paddingHorizontal: sizes.tiny,
       alignSelf: 'center',
     });
@@ -64,8 +62,6 @@ describe('BaseButton', () => {
 
     expect(getByTestId('BaseButton')).toHaveStyle({
       borderRadius: radius.small,
-      borderWidth: borders.hairline,
-      paddingVertical: 17,
       paddingHorizontal: sizes.tiny,
       backgroundColor: colors.solidPrimaryMedium,
       borderColor: colors.solidPrimaryMedium,

--- a/src/components/Buttons/__tests__/utils.test.tsx
+++ b/src/components/Buttons/__tests__/utils.test.tsx
@@ -6,7 +6,8 @@ import { colors, sizes } from '@magnetis/astro-tokens';
 import { AlertIcon } from '@components/Icons';
 
 import {
-  getButtonPadding,
+  getButtonHeight,
+  getButtonHorizontalPadding,
   getLineHeight,
   getIcon,
   getIconProperties,
@@ -15,28 +16,48 @@ import {
 } from '../utils';
 
 describe('Button/utils', () => {
-  it('getButtonPadding', () => {
-    expect(getButtonPadding('small', { isIconButton: false })).toEqual({
-      paddingVertical: 10,
-      paddingHorizontal: sizes.micro,
+  it('getButtonHeight', () => {
+    expect(getButtonHeight('small')).toEqual({
+      height: sizes.small,
     });
-    expect(getButtonPadding('medium', { isIconButton: false })).toEqual({
-      paddingVertical: 17,
-      paddingHorizontal: sizes.tiny,
+    expect(getButtonHeight('medium')).toEqual({
+      height: sizes.large,
     });
-    expect(getButtonPadding('large', { isIconButton: false })).toEqual({
-      paddingVertical: 20,
-      paddingHorizontal: sizes.smaller,
+    expect(getButtonHeight('large')).toEqual({
+      height: sizes.larger,
     });
-    expect(getButtonPadding('xlarge', { isIconButton: false })).toEqual({
-      paddingVertical: 22,
-      paddingHorizontal: sizes.smaller,
+    expect(getButtonHeight('xlarge')).toEqual({
+      height: sizes.great,
     });
 
-    expect(getButtonPadding('small', { isIconButton: true })).toEqual({ paddingVertical: 10, paddingHorizontal: 10 });
-    expect(getButtonPadding('medium', { isIconButton: true })).toEqual({ paddingVertical: 17, paddingHorizontal: 17 });
-    expect(getButtonPadding('large', { isIconButton: true })).toEqual({ paddingVertical: 20, paddingHorizontal: 20 });
-    expect(getButtonPadding('xlarge', { isIconButton: true })).toEqual({ paddingVertical: 22, paddingHorizontal: 22 });
+    expect(getButtonHeight('small')).toEqual({ height: 32 });
+    expect(getButtonHeight('medium')).toEqual({ height: 48 });
+    expect(getButtonHeight('large')).toEqual({ height: 56 });
+    expect(getButtonHeight('xlarge')).toEqual({ height: 64 });
+  });
+
+  it('getButtonHorizontalPadding', () => {
+    expect(getButtonHorizontalPadding('small')).toEqual({ width: undefined, paddingHorizontal: sizes.micro });
+    expect(getButtonHorizontalPadding('medium')).toEqual({ width: undefined, paddingHorizontal: sizes.tiny });
+    expect(getButtonHorizontalPadding('large')).toEqual({ width: undefined, paddingHorizontal: sizes.smaller });
+    expect(getButtonHorizontalPadding('xlarge')).toEqual({ width: undefined, paddingHorizontal: sizes.smaller });
+
+    expect(getButtonHorizontalPadding('small', { isIconButton: true })).toEqual({
+      width: sizes.small,
+      paddingHorizontal: 0,
+    });
+    expect(getButtonHorizontalPadding('medium', { isIconButton: true })).toEqual({
+      width: sizes.large,
+      paddingHorizontal: 0,
+    });
+    expect(getButtonHorizontalPadding('large', { isIconButton: true })).toEqual({
+      width: sizes.larger,
+      paddingHorizontal: 0,
+    });
+    expect(getButtonHorizontalPadding('xlarge', { isIconButton: true })).toEqual({
+      width: sizes.great,
+      paddingHorizontal: 0,
+    });
   });
 
   it('getLineHeight', () => {

--- a/src/components/Buttons/utils.ts
+++ b/src/components/Buttons/utils.ts
@@ -11,32 +11,52 @@ interface GetPropertiesOptionsParam {
   isIconButton: boolean;
 }
 
+const defaultOptions = {
+  isIconButton: false,
+};
+
 /**
- * Calculates button padding according to button size and if should have horizontal padding
+ * Calculates button height according to button size
  * @param {Size} size Valid **Size**
- * @param {GetPropertiesOptionsParam} options Options object
+ */
+export function getButtonHeight(size: Size) {
+  const buttonHeight = {
+    small: sizes.small,
+    medium: sizes.large,
+    large: sizes.larger,
+    xlarge: sizes.great,
+  };
+
+  return {
+    height: buttonHeight[size],
+  };
+}
+
+/**
+ * Calculates button horizontal padding according to button size
+ * @param {Size} size Valid **Size**
  * @param options.isIconButton If button is icon button
  */
-export function getButtonPadding(size: Size, options: GetPropertiesOptionsParam) {
+export function getButtonHorizontalPadding(size: Size, options: GetPropertiesOptionsParam = defaultOptions) {
   const { isIconButton } = options;
 
-  const regularHorizontalPadding = {
+  const iconButtonWidth = {
+    small: sizes.small,
+    medium: sizes.large,
+    large: sizes.larger,
+    xlarge: sizes.great,
+  };
+
+  const buttonHorizontalPadding = {
     small: sizes.micro,
     medium: sizes.tiny,
     large: sizes.smaller,
     xlarge: sizes.smaller,
   };
 
-  const regularVerticalPadding = {
-    small: 10,
-    medium: 17,
-    large: 20,
-    xlarge: 22,
-  };
-
   return {
-    paddingHorizontal: isIconButton ? regularVerticalPadding[size] : regularHorizontalPadding[size],
-    paddingVertical: regularVerticalPadding[size],
+    width: isIconButton ? iconButtonWidth[size] : undefined,
+    paddingHorizontal: isIconButton ? 0 : buttonHorizontalPadding[size],
   };
 }
 

--- a/src/components/ButtonsGroup/ButtonsGroup.tsx
+++ b/src/components/ButtonsGroup/ButtonsGroup.tsx
@@ -4,6 +4,8 @@ import { sizes } from '@magnetis/astro-tokens';
 
 import Button from '@components/Buttons/Button';
 
+import type { ButtonVariant } from '@components/Buttons/types';
+
 type Item = {
   value: string;
   onPressItem: () => void;
@@ -13,10 +15,18 @@ export interface ButtonsGroupProps extends PressableProps {
   items: Item[];
   inversed?: boolean;
   rounded?: boolean;
+  legacy?: boolean;
 }
 
-function ButtonsGroup({ testID, items, inversed, ...props }: ButtonsGroupProps) {
+function ButtonsGroup({ testID, items, inversed, legacy, rounded, ...props }: ButtonsGroupProps) {
   const [activeItem, setActiveItem] = useState(0);
+
+  function getButtonGroupVariant(index: number): ButtonVariant {
+    if (activeItem === index && legacy) return 'legacy';
+    if (activeItem === index && !legacy) return 'primary';
+    if (inversed) return 'inversed';
+    return 'secondary';
+  }
 
   return (
     <FlatList
@@ -25,18 +35,17 @@ function ButtonsGroup({ testID, items, inversed, ...props }: ButtonsGroupProps) 
       style={styles.container}
       contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
       horizontal
-      bounces={false}
       showsHorizontalScrollIndicator={false}
       keyExtractor={(item) => item.value}
       ItemSeparatorComponent={() => <View style={styles.itemContainer} />}
       renderItem={({ item, index }) => (
         <Button
           {...props}
-          accessibilityLabel={item.value}
           size="small"
           type={activeItem === index ? 'solid' : 'subtle'}
-          variant={activeItem === index ? 'primary' : inversed ? 'inversed' : 'secondary'}
+          variant={getButtonGroupVariant(index)}
           text={item.value}
+          rounded={legacy || rounded}
           onPress={() => {
             setActiveItem(index);
             item.onPressItem();

--- a/src/components/ButtonsGroup/__tests__/ButtonsGroup.test.tsx
+++ b/src/components/ButtonsGroup/__tests__/ButtonsGroup.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import { colors, radius } from '@magnetis/astro-tokens';
+import { colors as legacyColors } from '@magnetis/astro-galaxy-tokens';
 
 import ButtonsGroup from '../ButtonsGroup';
 
@@ -25,46 +26,60 @@ describe('ButtonsGroup', () => {
   });
 
   it('should renders correctly with default props', () => {
-    const { getByA11yLabel } = render(<ButtonsGroup {...initialProps} />);
+    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} />);
 
-    expect(getByA11yLabel('lorem')).toHaveStyle({
+    expect(getAllByTestId('Button')[0]).toHaveStyle({
       backgroundColor: colors.solidPrimaryMedium,
       borderRadius: radius.small,
     });
 
-    expect(getByA11yLabel('ipsum')).toHaveStyle({
+    expect(getAllByTestId('Button')[1]).toHaveStyle({
       backgroundColor: colors.transparentFaintSemitransparent,
       borderRadius: radius.small,
     });
   });
 
   it('should renders correctly with inversed prop', () => {
-    const { getByA11yLabel } = render(<ButtonsGroup {...initialProps} inversed />);
+    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} inversed />);
 
-    expect(getByA11yLabel('ipsum')).toHaveStyle({
+    expect(getAllByTestId('Button')[1]).toHaveStyle({
       backgroundColor: colors.transparentBrightSemitransparent,
       borderRadius: radius.small,
     });
   });
 
   it('should renders correctly with rounded prop', () => {
-    const { getByA11yLabel } = render(<ButtonsGroup {...initialProps} rounded />);
+    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} rounded />);
 
-    expect(getByA11yLabel('lorem')).toHaveStyle({
+    expect(getAllByTestId('Button')[0]).toHaveStyle({
       backgroundColor: colors.solidPrimaryMedium,
       borderRadius: radius.circular,
     });
 
-    expect(getByA11yLabel('ipsum')).toHaveStyle({
+    expect(getAllByTestId('Button')[1]).toHaveStyle({
+      backgroundColor: colors.transparentFaintSemitransparent,
+      borderRadius: radius.circular,
+    });
+  });
+
+  it('should renders correctly with legacy prop', () => {
+    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} legacy rounded />);
+
+    expect(getAllByTestId('Button')[0]).toHaveStyle({
+      backgroundColor: legacyColors.uranus500,
+      borderRadius: radius.circular,
+    });
+
+    expect(getAllByTestId('Button')[1]).toHaveStyle({
       backgroundColor: colors.transparentFaintSemitransparent,
       borderRadius: radius.circular,
     });
   });
 
   it('should call onPress when the button is pressed', () => {
-    const { getByText } = render(<ButtonsGroup {...initialProps} />);
+    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} />);
 
-    fireEvent.press(getByText('lorem'));
+    fireEvent.press(getAllByTestId('Button')[0]);
 
     expect(initialProps.items[0].onPressItem).toHaveBeenCalledTimes(1);
   });

--- a/src/components/ButtonsGroup/stories/ButtonsGroup.story.tsx
+++ b/src/components/ButtonsGroup/stories/ButtonsGroup.story.tsx
@@ -19,11 +19,17 @@ storiesOf('Buttons Group', module).add('Buttons Group', () => (
         items={ITEMS}
         inversed={boolean('inversed', true)}
         rounded={boolean('rounded', false)}
+        legacy={boolean('legacy', true)}
         onPress={() => console.log('value')}
       />
     </View>
     <View style={{ marginTop: sizes.mini }}>
-      <ButtonsGroup rounded={boolean('rounded', false)} items={ITEMS} onPress={() => console.log('value')} />
+      <ButtonsGroup
+        items={ITEMS}
+        rounded={boolean('rounded', false)}
+        legacy={boolean('legacy', false)}
+        onPress={() => console.log('value')}
+      />
     </View>
   </SafeAreaView>
 ));


### PR DESCRIPTION
# What

Add rounded prop to render buttons group with legacy layout

# Why

To use the component with the legacy interface

# How

- Add `legacy` prop to render new component

# Sample

<img width="157" alt="Captura de Tela 2021-11-10 às 16 47 37" src="https://user-images.githubusercontent.com/24248893/141183337-0d6d8d67-19de-4b19-b130-28f39d7f48b9.png">

# QA

Select the buttons group and check the border radius of buttons needs to turn rounded
