### PR TITLE
fix(button): fix solid inversed text color

### DIFF
--- a/src/components/Buttons/__tests__/utils.test.tsx
+++ b/src/components/Buttons/__tests__/utils.test.tsx
@@ -170,7 +170,7 @@ describe('Button/utils', () => {
 
     it('inversed', () => {
       expect(getButtonProperties('inversed', 'solid')).toEqual({
-        textColor: colors.solidFaintLight,
+        textColor: colors.solidFaintDarkest,
         backgroundColor: colors.solidBrightLightest,
       });
       expect(getButtonProperties('inversed', 'subtle')).toEqual({

--- a/src/components/Buttons/utils.ts
+++ b/src/components/Buttons/utils.ts
@@ -128,7 +128,7 @@ export function getButtonProperties(variant: ButtonVariant = 'primary', type: Bu
       ghost: { textColor: colors.solidSuccessDark, backgroundColor: 'transparent' },
     },
     inversed: {
-      solid: { textColor: colors.solidFaintLight, backgroundColor: colors.solidBrightLightest },
+      solid: { textColor: colors.solidFaintDarkest, backgroundColor: colors.solidBrightLightest },
       subtle: { textColor: colors.solidBrightLightest, backgroundColor: colors.transparentBrightSemitransparent },
       outline: { textColor: colors.solidBrightLightest, backgroundColor: 'transparent' },
       ghost: { textColor: colors.solidBrightLightest, backgroundColor: 'transparent' },


### PR DESCRIPTION
# What

Fix button solid inversed text color

# Sample

<img width="318" alt="Captura de Tela 2022-01-06 às 12 01 45" src="https://user-images.githubusercontent.com/24248893/148403184-3b25dcd9-ad4b-4fa0-b35f-55ba458ee59f.png">

# QA

Select the button with type `inversed` and variant `solid`


