### PR TITLE
refactor(buttonsgroup): add containerJustifyContent and initialActive…

### DIFF
--- a/src/components/ButtonsGroup/ButtonsGroup.tsx
+++ b/src/components/ButtonsGroup/ButtonsGroup.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { FlatList, PressableProps, StyleSheet, View } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 import { sizes } from '@magnetis/astro-tokens';
 
 import Button from '@components/Buttons/Button';
 
+import type { ViewStyle, PressableProps } from 'react-native';
 import type { ButtonVariant } from '@components/Buttons/types';
 
 type Item = {
@@ -12,14 +13,25 @@ type Item = {
 };
 
 export interface ButtonsGroupProps extends PressableProps {
-  items: Item[];
+  contentContainerStyle?: ViewStyle;
+  initialActiveItemIndex?: number;
   inversed?: boolean;
-  rounded?: boolean;
+  items: Item[];
   legacy?: boolean;
+  rounded?: boolean;
 }
 
-function ButtonsGroup({ testID, items, inversed, legacy, rounded, ...props }: ButtonsGroupProps) {
-  const [activeItem, setActiveItem] = useState(0);
+function ButtonsGroup({
+  contentContainerStyle = {},
+  initialActiveItemIndex = 0,
+  inversed,
+  items,
+  legacy,
+  rounded,
+  testID,
+  ...props
+}: ButtonsGroupProps) {
+  const [activeItem, setActiveItem] = useState(initialActiveItemIndex);
 
   function getButtonGroupVariant(index: number): ButtonVariant {
     if (activeItem === index && legacy) return 'legacy';
@@ -30,10 +42,10 @@ function ButtonsGroup({ testID, items, inversed, legacy, rounded, ...props }: Bu
 
   return (
     <FlatList
+      contentContainerStyle={{ ...styles.contentContainerStyle, ...contentContainerStyle }}
       testID={testID}
       data={items}
       style={styles.container}
-      contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
       horizontal
       showsHorizontalScrollIndicator={false}
       keyExtractor={(item) => item.value}
@@ -59,6 +71,10 @@ function ButtonsGroup({ testID, items, inversed, legacy, rounded, ...props }: Bu
 const styles = StyleSheet.create({
   container: {
     flexGrow: 0,
+  },
+  contentContainerStyle: {
+    flexGrow: 1,
+    justifyContent: 'center',
   },
   itemContainer: {
     marginLeft: sizes.nano,

--- a/src/components/ButtonsGroup/__tests__/ButtonsGroup.test.tsx
+++ b/src/components/ButtonsGroup/__tests__/ButtonsGroup.test.tsx
@@ -16,6 +16,7 @@ const ITEMS = [
 const initialProps: ButtonsGroupProps = {
   items: ITEMS,
   inversed: false,
+  testID: 'ButtonsGroup',
 };
 
 describe('ButtonsGroup', () => {
@@ -26,7 +27,9 @@ describe('ButtonsGroup', () => {
   });
 
   it('should renders correctly with default props', () => {
-    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} />);
+    const { getByTestId, getAllByTestId } = render(<ButtonsGroup {...initialProps} />);
+
+    expect(getByTestId('ButtonsGroup')).toHaveProp('contentContainerStyle', { flexGrow: 1, justifyContent: 'center' });
 
     expect(getAllByTestId('Button')[0]).toHaveStyle({
       backgroundColor: colors.solidPrimaryMedium,
@@ -40,7 +43,9 @@ describe('ButtonsGroup', () => {
   });
 
   it('should renders correctly with inversed prop', () => {
-    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} inversed />);
+    const { getByTestId, getAllByTestId } = render(<ButtonsGroup {...initialProps} inversed />);
+
+    expect(getByTestId('ButtonsGroup')).toHaveProp('contentContainerStyle', { flexGrow: 1, justifyContent: 'center' });
 
     expect(getAllByTestId('Button')[1]).toHaveStyle({
       backgroundColor: colors.transparentBrightSemitransparent,
@@ -49,7 +54,9 @@ describe('ButtonsGroup', () => {
   });
 
   it('should renders correctly with rounded prop', () => {
-    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} rounded />);
+    const { getByTestId, getAllByTestId } = render(<ButtonsGroup {...initialProps} rounded />);
+
+    expect(getByTestId('ButtonsGroup').props.contentContainerStyle).toEqual({ flexGrow: 1, justifyContent: 'center' });
 
     expect(getAllByTestId('Button')[0]).toHaveStyle({
       backgroundColor: colors.solidPrimaryMedium,
@@ -63,7 +70,9 @@ describe('ButtonsGroup', () => {
   });
 
   it('should renders correctly with legacy prop', () => {
-    const { getAllByTestId } = render(<ButtonsGroup {...initialProps} legacy rounded />);
+    const { getByTestId, getAllByTestId } = render(<ButtonsGroup {...initialProps} legacy rounded />);
+
+    expect(getByTestId('ButtonsGroup')).toHaveProp('contentContainerStyle', { flexGrow: 1, justifyContent: 'center' });
 
     expect(getAllByTestId('Button')[0]).toHaveStyle({
       backgroundColor: legacyColors.uranus500,
@@ -73,6 +82,27 @@ describe('ButtonsGroup', () => {
     expect(getAllByTestId('Button')[1]).toHaveStyle({
       backgroundColor: colors.transparentFaintSemitransparent,
       borderRadius: radius.circular,
+    });
+  });
+
+  it('should renders correctly with contentContainerStyle prop', () => {
+    const { getByTestId, getAllByTestId } = render(
+      <ButtonsGroup {...initialProps} contentContainerStyle={{ justifyContent: 'space-between' }} />
+    );
+
+    expect(getByTestId('ButtonsGroup')).toHaveProp('contentContainerStyle', {
+      flexGrow: 1,
+      justifyContent: 'space-between',
+    });
+
+    expect(getAllByTestId('Button')[0]).toHaveStyle({
+      backgroundColor: colors.solidPrimaryMedium,
+      borderRadius: radius.small,
+    });
+
+    expect(getAllByTestId('Button')[1]).toHaveStyle({
+      backgroundColor: colors.transparentFaintSemitransparent,
+      borderRadius: radius.small,
     });
   });
 

--- a/src/components/ButtonsGroup/stories/ButtonsGroup.story.tsx
+++ b/src/components/ButtonsGroup/stories/ButtonsGroup.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SafeAreaView, View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select, object } from '@storybook/addon-knobs';
 import { colors, sizes } from '@magnetis/astro-tokens';
 
 import ButtonsGroup from '../ButtonsGroup';
@@ -12,22 +12,28 @@ const ITEMS = [
   { value: 'dolor', onPressItem: () => console.log('dolor') },
 ];
 
+const ITEMS_INDEX = ITEMS.map((_, index) => index);
+
 storiesOf('Buttons Group', module).add('Buttons Group', () => (
   <SafeAreaView>
     <View style={{ backgroundColor: colors.solidFaintDarkest }}>
       <ButtonsGroup
-        items={ITEMS}
+        contentContainerStyle={object('contentContainerStyle', {})}
+        initialActiveItemIndex={select('initialActiveItemIndex', ITEMS_INDEX, ITEMS_INDEX[0])}
         inversed={boolean('inversed', true)}
-        rounded={boolean('rounded', false)}
+        items={ITEMS}
         legacy={boolean('legacy', true)}
+        rounded={boolean('rounded', false)}
         onPress={() => console.log('value')}
       />
     </View>
     <View style={{ marginTop: sizes.mini }}>
       <ButtonsGroup
+        contentContainerStyle={object('contentContainerStyle', {})}
+        initialActiveItemIndex={select('initialActiveItemIndex', ITEMS_INDEX, ITEMS_INDEX[0])}
         items={ITEMS}
-        rounded={boolean('rounded', false)}
         legacy={boolean('legacy', false)}
+        rounded={boolean('rounded', false)}
         onPress={() => console.log('value')}
       />
     </View>


### PR DESCRIPTION
# What

Add contentContainerStyle and initialActiveitemIndex props to ButtonsGroup

# Why

Enable customization of items container and enable initial initial active index definition.

# How

- Add contentContainerStyle to set container items style
- Add initialActiveItemIndex to set initial active item

# Sample

https://user-images.githubusercontent.com/13890272/153067615-4eeb20ab-2636-4e10-897f-0a18f77f4c2b.mov

# QA

Flows:
- Run the app
- Validate if it's possible define the items distribution
- Validate if it's possible define the initial active item

<!-- ✅ TODOs -->
<!-- Assign at least one manteiner to review this PR -->
<!-- Assign everyone who worked on this PR -->

<!-- EXTRAS -->
<!-- 💸 Describe possible tech debits -->
