### PR TITLE
chore: bump version to v2.0.0-next.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# [2.0.0-next.3](https://github.com/magnetis/astro-native/compare/v2.0.0-next.2...v2.0.0-next.3) (2021-11-08)
+# [2.0.0-next.4](https://github.com/magnetis/astro-native/compare/v2.0.0-next.3...v2.0.0-next.4) (2022-02-09)
+
+### Refactor
+
+- **buttonsgroup**: add contentContainerStyle and initialActiveItemIndex props ([60dc7a1](https://github.com/magnetis/astro-native/commit/60dc7a1788c55200c22be0387136585daa5cfc63))
+
+# [2.0.0-next.3](https://github.com/magnetis/astro-native/compare/v2.0.0-next.2...v2.0.0-next.3) (2022-01-07)
 
 ### Bugfix
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-native",
-  "version": "2.0.0-next.3",
+  "version": "2.0.0-next.4",
   "description": "Astro components for React Native",
   "homepage": "https://astro-galaxy.magnetis.com.br/",
   "files": [


### PR DESCRIPTION
# [2.0.0-next.4](https://github.com/magnetis/astro-native/compare/v2.0.0-next.3...v2.0.0-next.4) (2022-02-09)

### Refactor

- **buttonsgroup**: add contentContainerStyle and initialActiveItemIndex props ([60dc7a1](https://github.com/magnetis/astro-native/commit/60dc7a1788c55200c22be0387136585daa5cfc63))