### PR TITLE
[AST-164] Fix legacy variant layout for outline and ghost button types

### DIFF
--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -34,7 +34,7 @@ function Button({
     activityIndicatorColor: textColor,
     backgroundColor,
     borderColor: type === 'outline' ? textColor : 'transparent',
-    borderWidth: type === 'outline' ? 1 : 0,
+    borderWidth: type === 'outline' ? (variant === 'legacy' ? 2 : 1) : 0,
     borderRadius: rounded ? radius.circular : radius.small,
     disabled,
     textColor,

--- a/src/components/Buttons/__tests__/utils.test.tsx
+++ b/src/components/Buttons/__tests__/utils.test.tsx
@@ -216,11 +216,11 @@ describe('Button/utils', () => {
         backgroundColor: legacyColors.uranus500,
       });
       expect(getButtonProperties('legacy', 'outline')).toEqual({
-        textColor: colors.solidBrightLightest,
+        textColor: legacyColors.uranus500,
         backgroundColor: 'transparent',
       });
       expect(getButtonProperties('legacy', 'ghost')).toEqual({
-        textColor: colors.solidBrightLightest,
+        textColor: legacyColors.uranus500,
         backgroundColor: 'transparent',
       });
     });

--- a/src/components/Buttons/utils.ts
+++ b/src/components/Buttons/utils.ts
@@ -142,8 +142,8 @@ export function getButtonProperties(variant: ButtonVariant = 'primary', type: Bu
     legacy: {
       solid: { textColor: colors.solidBrightLightest, backgroundColor: legacyColors.uranus500 },
       subtle: { textColor: colors.solidBrightLightest, backgroundColor: legacyColors.uranus500 },
-      outline: { textColor: colors.solidBrightLightest, backgroundColor: 'transparent' },
-      ghost: { textColor: colors.solidBrightLightest, backgroundColor: 'transparent' },
+      outline: { textColor: legacyColors.uranus500, backgroundColor: 'transparent' },
+      ghost: { textColor: legacyColors.uranus500, backgroundColor: 'transparent' },
     },
   }[variant][type];
 }


### PR DESCRIPTION
# What

Fix legacy buttons when using outline or ghost types

# Why

Because it's broken, render with wrong colors.

# How

Change colors in legacy variant.

# Sample

https://user-images.githubusercontent.com/1580205/155006821-4bfcfb16-b309-4072-ad85-dc50132bf367.mp4

# QA

1. Run storybook;
2. Run astro-native app;
3. In button, change to legacy variant;
4. Also in button, change to outline and ghost types;