### PR TITLE
Add Button pressed feedback

### DIFF
--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -11,12 +11,13 @@ export interface BaseButtonProps extends PressableProps {
   activityIndicatorColor: string;
   backgroundColor: string;
   borderColor: string;
-  fill?: boolean;
   borderRadius: number;
-  loading?: boolean;
+  fill?: boolean;
   isIconButton?: boolean;
-  textColor: string;
+  loading?: boolean;
+  opacity?: number;
   size?: Size;
+  textColor: string;
 }
 
 const styles = StyleSheet.create({
@@ -35,9 +36,10 @@ function BaseButton({
   activityIndicatorColor,
   children,
   fill = false,
-  loading = false,
-  size = 'medium',
   isIconButton = false,
+  loading = false,
+  opacity = 0.7,
+  size = 'medium',
   ...props
 }: BaseButtonProps) {
   const [hitSlop, setHitSlop] = useState<HitSlop>({ top: 0, bottom: 0, left: 0, right: 0 });
@@ -74,7 +76,7 @@ function BaseButton({
     <Pressable
       accessibilityRole="button"
       {...props}
-      style={[styles.button, computedStyles]}
+      style={({ pressed }) => [{ opacity: pressed ? opacity : 1 }, styles.button, computedStyles]}
       hitSlop={props.hitSlop ?? hitSlop}
       onLayout={onLayoutButton}
     >

--- a/src/components/Buttons/__tests__/BaseButton.test.tsx
+++ b/src/components/Buttons/__tests__/BaseButton.test.tsx
@@ -27,17 +27,18 @@ describe('BaseButton', () => {
 
   it('should renders correctly with default props', () => {
     const { getByTestId } = render(
-      <BaseButton {...initialProps}>
+      <BaseButton {...initialProps} testOnly_pressed>
         <ButtonText />
       </BaseButton>
     );
 
     expect(getByTestId('BaseButton')).toHaveStyle({
+      alignSelf: 'center',
       backgroundColor: colors.solidPrimaryMedium,
       borderColor: colors.solidPrimaryMedium,
       borderRadius: radius.small,
       paddingHorizontal: sizes.tiny,
-      alignSelf: 'center',
+      opacity: 0.7,
     });
   });
 
@@ -61,13 +62,13 @@ describe('BaseButton', () => {
     );
 
     expect(getByTestId('BaseButton')).toHaveStyle({
-      borderRadius: radius.small,
-      paddingHorizontal: sizes.tiny,
       backgroundColor: colors.solidPrimaryMedium,
+      borderRadius: radius.small,
       borderColor: colors.solidPrimaryMedium,
+      paddingHorizontal: sizes.tiny,
     });
 
-    expect(getByTestId('BaseButton.ActivityIndicator').props.color).toEqual(colors.solidBrightLightest);
+    expect(getByTestId('BaseButton.ActivityIndicator')).toHaveProp('color', colors.solidBrightLightest);
   });
 
   it('should renders with width of 100% when fill is true', () => {
@@ -78,6 +79,16 @@ describe('BaseButton', () => {
     );
 
     expect(getByTestId('BaseButton')).toHaveStyle({ width: '100%' });
+  });
+
+  it('should renders with custom opacity when receive opacity prop', () => {
+    const { getByTestId } = render(
+      <BaseButton {...initialProps} opacity={0.3} testOnly_pressed>
+        <ButtonText />
+      </BaseButton>
+    );
+
+    expect(getByTestId('BaseButton')).toHaveStyle({ opacity: 0.3 });
   });
 
   it('should renders with min hit slop 50X48 when button width and height is small', () => {
@@ -100,10 +111,10 @@ describe('BaseButton', () => {
     });
 
     expect(baseButton.props.hitSlop).toStrictEqual({
-      top: 14,
       bottom: 14,
       left: 14,
       right: 14,
+      top: 14,
     });
   });
 
@@ -127,10 +138,10 @@ describe('BaseButton', () => {
     });
 
     expect(baseButton.props.hitSlop).toStrictEqual({
-      top: 0,
       bottom: 0,
       left: 14,
       right: 14,
+      top: 0,
     });
   });
 
@@ -154,10 +165,10 @@ describe('BaseButton', () => {
     });
 
     expect(baseButton.props.hitSlop).toStrictEqual({
-      top: 14,
       bottom: 14,
       left: 0,
       right: 0,
+      top: 14,
     });
   });
 
@@ -181,10 +192,10 @@ describe('BaseButton', () => {
     });
 
     expect(baseButton.props.hitSlop).toStrictEqual({
-      top: 0,
       bottom: 0,
       left: 0,
       right: 0,
+      top: 0,
     });
   });
 
@@ -206,7 +217,6 @@ describe('BaseButton', () => {
         },
       });
     });
-
     expect(baseButton.props.hitSlop).toStrictEqual({ bottom: 0, left: 0, right: 0, top: 0 });
   });
 
@@ -232,10 +242,10 @@ describe('BaseButton', () => {
 
     expect(onLayout).toBeCalledTimes(1);
     expect(baseButton.props.hitSlop).toStrictEqual({
-      top: 14,
       bottom: 14,
       left: 14,
       right: 14,
+      top: 14,
     });
   });
 });

--- a/src/components/Buttons/__tests__/Button.test.tsx
+++ b/src/components/Buttons/__tests__/Button.test.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
+
 import { colors, radius, typography } from '@magnetis/astro-tokens';
 
 import Button from '../Button';
 import type { ButtonProps } from '..';
 
 const initialProps: ButtonProps = {
-  disabled: false,
-  fill: false,
-  loading: false,
-  size: 'medium',
   text: 'text',
-  type: 'solid',
-  variant: 'primary',
   onPress: jest.fn(),
 };
 
@@ -59,13 +54,9 @@ describe('Button', () => {
       lineHeight: typography.fontSizeMini * 1.5,
     });
 
-    expect(getByTestId('Button.IconLeftContainer')).toHaveStyle({
-      marginRight: 4,
-    });
+    expect(getByTestId('Button.IconLeftContainer')).toBeTruthy();
 
-    expect(getByTestId('Button.IconRightContainer')).toHaveStyle({
-      marginLeft: 4,
-    });
+    expect(getByTestId('Button.IconRightContainer')).toBeTruthy();
   });
 
   it('should renders correctly with rounded layout', () => {

--- a/src/components/Buttons/stories/Button.story.tsx
+++ b/src/components/Buttons/stories/Button.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 
 import { Button } from '..';
 import { iconOptions } from '@root/storybook/options';
@@ -13,12 +13,13 @@ storiesOf('Next Buttons', module).add('Button', () => (
     fill={boolean('fill', false)}
     iconLeft={select('iconLeft', iconOptions, iconOptions[0])}
     iconRight={select('iconRight', iconOptions, iconOptions[0])}
-    rounded={boolean('rounded', false)}
     loading={boolean('loading', false)}
+    opacity={number('opacity', 0.7)}
+    rounded={boolean('rounded', false)}
     size={select('size', sizeOptions, sizeOptions[1])}
     text={text('text', 'Button')}
-    variant={select('variant', buttonVariantOptions, buttonVariantOptions[0])}
     type={select('type', buttonTypeOptions, buttonTypeOptions[0])}
+    variant={select('variant', buttonVariantOptions, buttonVariantOptions[0])}
     onPress={() => console.log('Pressed')}
   />
 ));

--- a/src/components/Buttons/types.ts
+++ b/src/components/Buttons/types.ts
@@ -24,10 +24,12 @@ export interface ButtonProps extends PressableProps {
   iconLeft?: IconID;
   /** Defines right icon name */
   iconRight?: IconID;
-  /** Renders rounded border radius. Defaults to `false`.  */
-  rounded?: boolean;
   /** Shows activity indicator inside button when true. Defaults to `false`.  */
   loading?: boolean;
+  /** Feedback opacity for button. */
+  opacity?: number;
+  /** Renders rounded border radius. Defaults to `false`.  */
+  rounded?: boolean;
   /** Specifies button size. Defaults to `"medium"`. */
   size?: Size;
   /** Text to be shown inside the button */


### PR DESCRIPTION
# What

Improve the visual feedback given to the user when he presses the button

# Why

To improve the accessibility of the application. When the buttons are clicked return the action was done.

# How

- Added `pressed` functionality in `Presseble` passing default `opacity` 0.7

# Sample

https://user-images.githubusercontent.com/44146877/161124728-52a2f2a0-89f0-40a9-a71e-2447875ee8e9.mov

# QA



