### PR TITLE
Updated tokens in getButtonProperties

### DIFF
--- a/src/components/Buttons/__tests__/utils.test.tsx
+++ b/src/components/Buttons/__tests__/utils.test.tsx
@@ -151,7 +151,7 @@ describe('Button/utils', () => {
 
     it('ghost', () => {
       expect(getButtonProperties('success', 'solid')).toEqual({
-        textColor: colors.solidBrightLightest,
+        textColor: colors.solidFaintDarkest,
         backgroundColor: colors.solidSuccessMedium,
       });
       expect(getButtonProperties('success', 'subtle')).toEqual({

--- a/src/components/Buttons/utils.ts
+++ b/src/components/Buttons/utils.ts
@@ -122,7 +122,7 @@ export function getButtonProperties(variant: ButtonVariant = 'primary', type: Bu
       ghost: { textColor: colors.solidAlertMedium, backgroundColor: 'transparent' },
     },
     success: {
-      solid: { textColor: colors.solidBrightLightest, backgroundColor: colors.solidSuccessMedium },
+      solid: { textColor: colors.solidFaintDarkest, backgroundColor: colors.solidSuccessMedium },
       subtle: { textColor: colors.solidSuccessDark, backgroundColor: colors.transparentSuccessSemitransparent },
       outline: { textColor: colors.solidSuccessDark, backgroundColor: 'transparent' },
       ghost: { textColor: colors.solidSuccessDark, backgroundColor: 'transparent' },


### PR DESCRIPTION
# What

Changing some tokens that were not updated

# Why

It is necessary to ensure that all variants and styles of controls must be available to be used when applying the component.

# How

Comparing figma tokens doc with properties and changing what was needed
