### PR TITLE
Add Button pressed feedback

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,7 +17,7 @@ target 'AstroNative' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
+  use_flipper!({ 'Flipper' => '0.87.0', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1' })
   post_install do |installer|
     flipper_post_install(installer)
   end

--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { View, StyleSheet, ActivityIndicator, Pressable, PressableProps, LayoutChangeEvent } from 'react-native';
 
 import type { HitSlop } from '../types';
@@ -12,17 +12,13 @@ interface BaseButtonProps extends PressableProps {
   activityIndicatorColor: string;
   backgroundColor: string;
   borderColor: string;
-  children: ReactElement;
-  disabled?: boolean;
   fill?: boolean;
   hasIcon?: boolean;
-  testID?: string;
   loading?: boolean;
   noHorizontalPadding?: boolean;
   opacity?: number;
   size?: ButtonSize;
   textColor: string;
-  onPress: () => void;
 }
 
 const styles = StyleSheet.create({

--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -8,20 +8,21 @@ import type { ButtonSize } from './types';
 import { getBorderRadius, getButtonPadding } from './utils';
 
 interface BaseButtonProps extends PressableProps {
-  children: ReactElement;
-  testID?: string;
   accessibilityLabel?: string;
-  loading?: boolean;
-  disabled?: boolean;
   activityIndicatorColor: string;
-  onPress: () => void;
   backgroundColor: string;
-  textColor: string;
   borderColor: string;
-  size?: ButtonSize;
-  noHorizontalPadding?: boolean;
+  children: ReactElement;
+  disabled?: boolean;
   fill?: boolean;
   hasIcon?: boolean;
+  testID?: string;
+  loading?: boolean;
+  noHorizontalPadding?: boolean;
+  opacity?: number;
+  size?: ButtonSize;
+  textColor: string;
+  onPress: () => void;
 }
 
 const styles = StyleSheet.create({
@@ -40,14 +41,15 @@ const styles = StyleSheet.create({
 });
 
 function BaseButton({
-  loading = false,
-  disabled = false,
   activityIndicatorColor,
   children,
-  size = 'medium',
-  noHorizontalPadding = false,
+  disabled = false,
   fill = false,
   hasIcon = false,
+  loading = false,
+  noHorizontalPadding = false,
+  opacity = 0.7,
+  size = 'medium',
   ...props
 }: BaseButtonProps) {
   const [hitSlop, setHitSlop] = useState<HitSlop>({ top: 0, bottom: 0, left: 0, right: 0 });
@@ -69,7 +71,6 @@ function BaseButton({
   const pressableProps = {
     onPress: props.onPress,
     disabled: disabled || loading,
-    style: [styles.button, computedStyles],
     testID: props.testID,
     hitSlop: typeof props.hitSlop !== 'undefined' ? props.hitSlop : hitSlop,
   };
@@ -89,7 +90,13 @@ function BaseButton({
   );
 
   return (
-    <Pressable accessibilityRole="button" {...props} {...pressableProps} onLayout={onLayoutButton}>
+    <Pressable
+      accessibilityRole="button"
+      {...props}
+      {...pressableProps}
+      style={({ pressed }) => [{ opacity: pressed ? opacity : 1 }, styles.button, computedStyles]}
+      onLayout={onLayoutButton}
+    >
       <View style={{ alignItems: 'center', justifyContent: 'center', flex: fill ? 1 : 0 }}>
         <View style={{ opacity: loading ? 0 : 1 }}>{children}</View>
         {loading && (

--- a/src/components/Buttons/__tests__/BaseButton.test.tsx
+++ b/src/components/Buttons/__tests__/BaseButton.test.tsx
@@ -26,7 +26,7 @@ describe('BaseButton', () => {
 
   it('renders correctly with default props', () => {
     const { getByTestId } = render(
-      <BaseButton {...props}>
+      <BaseButton {...props} testOnly_pressed>
         <ButtonText />
       </BaseButton>
     );
@@ -35,13 +35,14 @@ describe('BaseButton', () => {
 
     expect(baseButtonStyle).toEqual(
       expect.objectContaining({
+        alignSelf: 'center',
         backgroundColor: colors.uranus500,
         borderColor: colors.uranus500,
         borderRadius: 24,
         borderWidth: 2,
+        opacity: 0.7,
         paddingVertical: 8,
         paddingHorizontal: 46,
-        alignSelf: 'center',
       })
     );
   });
@@ -99,6 +100,16 @@ describe('BaseButton', () => {
     const baseButtonStyle = Object.assign({}, ...baseButton.props.style);
 
     expect(baseButtonStyle.width).toEqual('100%');
+  });
+
+  it('should renders with custom opacity when receive opacity prop', () => {
+    const { getByTestId } = render(
+      <BaseButton {...props} opacity={0.3} testOnly_pressed>
+        <ButtonText />
+      </BaseButton>
+    );
+
+    expect(getByTestId('BaseButton')).toHaveStyle({ opacity: 0.3 });
   });
 
   it('has min hit slop 50X48 when button width and height is small', () => {

--- a/src/components/Buttons/stories/GhostIconButton.story.tsx
+++ b/src/components/Buttons/stories/GhostIconButton.story.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select } from '@storybook/addon-knobs';
+import { boolean, number, select } from '@storybook/addon-knobs';
 
 import { GhostIconButton } from '..';
 import { buttonColorOptions, iconOptions, sizeOptions } from '@root/storybook/options';
 
 storiesOf('Buttons', module).add('GhostIconButton', () => (
   <GhostIconButton
-    onPress={() => console.log('Pressed')}
-    disabled={boolean('disabled', false)}
-    loading={boolean('loading', false)}
     color={select('color', buttonColorOptions, 'uranus')}
+    disabled={boolean('disabled', false)}
     icon={select('icon', iconOptions, iconOptions[0])}
+    loading={boolean('loading', false)}
+    opacity={number('opacity', 0.7)}
+    onPress={() => console.log('Pressed')}
     size={select('size', sizeOptions, 'medium')}
   />
 ));

--- a/src/components/Buttons/stories/GhostIconLabelButton.story.tsx
+++ b/src/components/Buttons/stories/GhostIconLabelButton.story.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 
 import { GhostIconLabelButton } from '..';
 import { buttonColorOptions, iconButtonPositionOptions, iconOptions, sizeOptions } from '@root/storybook/options';
 
 storiesOf('Buttons', module).add('GhostIconLabelButton', () => (
   <GhostIconLabelButton
-    text={text('text', 'Button')}
-    onPress={() => console.log('Pressed')}
-    disabled={boolean('disabled', false)}
-    loading={boolean('loading', false)}
-    fill={boolean('fill', false)}
     color={select('color', buttonColorOptions, 'uranus')}
+    disabled={boolean('disabled', false)}
+    fill={boolean('fill', false)}
     icon={select('icon', iconOptions, iconOptions[0])}
-    size={select('size', sizeOptions, 'medium')}
     iconPosition={select('iconPosition', iconButtonPositionOptions, 'left')}
+    loading={boolean('loading', false)}
+    onPress={() => console.log('Pressed')}
+    opacity={number('opacity', 0.7)}
+    size={select('size', sizeOptions, 'medium')}
+    text={text('text', 'Button')}
   />
 ));
 

--- a/src/components/Buttons/stories/IconButton.story.tsx
+++ b/src/components/Buttons/stories/IconButton.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select } from '@storybook/addon-knobs';
+import { boolean, number, select } from '@storybook/addon-knobs';
 
 import { IconButton } from '..';
 
@@ -8,11 +8,12 @@ import { buttonColorOptions, iconOptions, sizeOptions } from '@root/storybook/op
 
 storiesOf('Buttons', module).add('IconButton', () => (
   <IconButton
-    onPress={() => console.log('Pressed')}
-    disabled={boolean('disabled', false)}
-    loading={boolean('loading', false)}
     color={select('color', buttonColorOptions, 'uranus')}
+    disabled={boolean('disabled', false)}
     icon={select('icon', iconOptions, iconOptions[0])}
+    loading={boolean('loading', false)}
+    onPress={() => console.log('Pressed')}
+    opacity={number('opacity', 0.7)}
     size={select('size', sizeOptions, 'medium')}
   />
 ));

--- a/src/components/Buttons/stories/IconLabelButton.story.tsx
+++ b/src/components/Buttons/stories/IconLabelButton.story.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 
 import { IconLabelButton } from '..';
 import { buttonColorOptions, iconButtonPositionOptions, iconOptions, sizeOptions } from '@root/storybook/options';
 
 storiesOf('Buttons', module).add('IconLabelButton', () => (
   <IconLabelButton
-    text={text('text', 'Button')}
-    onPress={() => console.log('Pressed')}
-    disabled={boolean('disabled', false)}
-    loading={boolean('loading', false)}
-    fill={boolean('fill', false)}
     color={select('color', buttonColorOptions, 'uranus')}
+    disabled={boolean('disabled', false)}
+    fill={boolean('fill', false)}
     icon={select('icon', iconOptions, iconOptions[0])}
-    size={select('size', sizeOptions, 'medium')}
     iconPosition={select('iconPosition', iconButtonPositionOptions, 'left') as 'left' | 'right'}
+    loading={boolean('loading', false)}
+    onPress={() => console.log('Pressed')}
+    opacity={number('opacity', 0.7)}
+    size={select('size', sizeOptions, 'medium')}
+    text={text('text', 'Button')}
   />
 ));
 

--- a/src/components/Buttons/stories/OutlineButton.story.tsx
+++ b/src/components/Buttons/stories/OutlineButton.story.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 
 import { OutlineButton } from '..';
 import { buttonColorOptions, sizeOptions } from '@root/storybook/options';
 
 storiesOf('Buttons', module).add('OutlineButton', () => (
   <OutlineButton
-    text={text('text', 'Button')}
-    onPress={() => console.log('Pressed')}
-    disabled={boolean('disabled', false)}
-    loading={boolean('loading', false)}
-    fill={boolean('fill', false)}
     color={select('color', buttonColorOptions, 'uranus')}
+    disabled={boolean('disabled', false)}
+    fill={boolean('fill', false)}
+    loading={boolean('loading', false)}
+    onPress={() => console.log('Pressed')}
+    opacity={number('opacity', 0.7)}
     size={select('size', sizeOptions, 'medium')}
+    text={text('text', 'Button')}
   />
 ));
 

--- a/src/components/Buttons/stories/OutlineIconButton.story.tsx
+++ b/src/components/Buttons/stories/OutlineIconButton.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select } from '@storybook/addon-knobs';
+import { boolean, number, select } from '@storybook/addon-knobs';
 
 import { OutlineIconButton } from '..';
 
@@ -8,11 +8,12 @@ import { sizeOptions, buttonColorOptions, iconOptions } from '@root/storybook/op
 
 storiesOf('Buttons', module).add('OutlineIconButton', () => (
   <OutlineIconButton
-    onPress={() => console.log('Pressed')}
-    disabled={boolean('disabled', false)}
-    loading={boolean('loading', false)}
     color={select('color', buttonColorOptions, 'uranus')}
+    disabled={boolean('disabled', false)}
     icon={select('icon', iconOptions, iconOptions[0])}
+    loading={boolean('loading', false)}
+    onPress={() => console.log('Pressed')}
+    opacity={number('opacity', 0.7)}
     size={select('size', sizeOptions, 'medium')}
   />
 ));

--- a/src/components/Buttons/stories/OutlineIconLabelButton.story.tsx
+++ b/src/components/Buttons/stories/OutlineIconLabelButton.story.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 
 import { OutlineIconLabelButton } from '..';
 import { buttonColorOptions, iconButtonPositionOptions, iconOptions, sizeOptions } from '@root/storybook/options';
 
 storiesOf('Buttons', module).add('OutlineIconLabelButton', () => (
   <OutlineIconLabelButton
-    text={text('text', 'Button')}
-    onPress={() => console.log('Pressed')}
-    disabled={boolean('disabled', false)}
-    loading={boolean('loading', false)}
-    fill={boolean('fill', false)}
     color={select('color', buttonColorOptions, 'uranus')}
+    disabled={boolean('disabled', false)}
+    fill={boolean('fill', false)}
     icon={select('icon', iconOptions, iconOptions[0])}
-    size={select('size', sizeOptions, 'medium')}
     iconPosition={select('iconPosition', iconButtonPositionOptions, 'left')}
+    onPress={() => console.log('Pressed')}
+    opacity={number('opacity', 0.7)}
+    loading={boolean('loading', false)}
+    size={select('size', sizeOptions, 'medium')}
+    text={text('text', 'Button')}
   />
 ));
 

--- a/src/components/Buttons/stories/PrimaryButton.story.tsx
+++ b/src/components/Buttons/stories/PrimaryButton.story.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 
 import { PrimaryButton } from '..';
 import { buttonColorOptions, sizeOptions } from '@root/storybook/options';
 
 storiesOf('Buttons', module).add('PrimaryButton', () => (
   <PrimaryButton
-    text={text('text', 'Button')}
-    onPress={() => console.log('Pressed')}
-    disabled={boolean('disabled', false)}
-    loading={boolean('loading', false)}
-    fill={boolean('fill', false)}
     color={select('color', buttonColorOptions, 'uranus')}
+    disabled={boolean('disabled', false)}
+    fill={boolean('fill', false)}
+    loading={boolean('loading', false)}
+    onPress={() => console.log('Pressed')}
+    opacity={number('opacity', 0.7)}
     size={select('size', sizeOptions, 'medium')}
+    text={text('text', 'Button')}
   />
 ));
 

--- a/src/components/Buttons/types.ts
+++ b/src/components/Buttons/types.ts
@@ -8,25 +8,18 @@ export type ButtonSize = Size;
 export type ButtonColor = 'uranus' | 'earth' | 'venus' | 'mars' | 'moon' | 'space';
 
 export interface ButtonProps extends PressableProps {
-  accessibilityLabel?: string;
   /** Color to be used as background color of button. Defaults to `"uranus"`. */
   color?: ButtonColor;
-  /** Supress any user interaction with component. Defaults to `false`. */
-  disabled?: boolean;
   /** Button fills entire parent when set to true. Defaults to `false`. */
   fill?: boolean;
   /** Shows activity indicator inside button when true. Defaults to `false`.  */
   loading?: boolean;
-  /** Button press callback */
-  onPress: () => void;
   /** Feedback opacity for button. */
   opacity?: number;
   /** Specifies button size. Defaults to `"medium"`. */
   size?: ButtonSize;
   /** Text to be shown inside the button */
   text: string;
-  /** Used to locate this component in end-to-end tests */
-  testID?: string;
 }
 
 export interface IconLabelButtonProps extends ButtonProps {

--- a/src/components/Buttons/types.ts
+++ b/src/components/Buttons/types.ts
@@ -8,23 +8,25 @@ export type ButtonSize = Size;
 export type ButtonColor = 'uranus' | 'earth' | 'venus' | 'mars' | 'moon' | 'space';
 
 export interface ButtonProps extends PressableProps {
-  /** Text to be shown inside the button */
-  text: string;
+  accessibilityLabel?: string;
   /** Color to be used as background color of button. Defaults to `"uranus"`. */
   color?: ButtonColor;
-  /** Button press callback */
-  onPress: () => void;
-  /** Shows activity indicator inside button when true. Defaults to `false`.  */
-  loading?: boolean;
   /** Supress any user interaction with component. Defaults to `false`. */
   disabled?: boolean;
-  /** Used to locate this component in end-to-end tests */
-  testID?: string;
-  accessibilityLabel?: string;
-  /** Specifies button size. Defaults to `"medium"`. */
-  size?: ButtonSize;
   /** Button fills entire parent when set to true. Defaults to `false`. */
   fill?: boolean;
+  /** Shows activity indicator inside button when true. Defaults to `false`.  */
+  loading?: boolean;
+  /** Button press callback */
+  onPress: () => void;
+  /** Feedback opacity for button. */
+  opacity?: number;
+  /** Specifies button size. Defaults to `"medium"`. */
+  size?: ButtonSize;
+  /** Text to be shown inside the button */
+  text: string;
+  /** Used to locate this component in end-to-end tests */
+  testID?: string;
 }
 
 export interface IconLabelButtonProps extends ButtonProps {

--- a/storybook/options.ts
+++ b/storybook/options.ts
@@ -6,7 +6,7 @@ import type { IconID } from '@components/Icons';
 import { ButtonColor } from '@components/Buttons';
 
 export const colorOptions = Object.keys(colors).reduce((acc, key) => {
-  acc[key] = colors[(key as unknown) as keyof Colors];
+  acc[key] = colors[key as unknown as keyof Colors];
   return acc;
 }, {} as { [key: string]: Colors[keyof Colors] });
 
@@ -27,6 +27,6 @@ export const gradientOptions = Object.keys(gradients).reduce(
 
 export const iconOptions: Array<IconID> = Object.keys(icons).map((key) => key.replace('Icon', '') as IconID);
 
-export const buttonColorOptions: ButtonColor[] = ['uranus', 'venus', 'mars', 'earth'];
+export const buttonColorOptions: ButtonColor[] = ['uranus', 'venus', 'mars', 'earth', 'moon'];
 
 export const iconButtonPositionOptions: Array<'left' | 'right'> = ['left', 'right'];


### PR DESCRIPTION
# What
(in main)
Improve the visual feedback given to the user when he presses the button

# Why

To improve the accessibility of the application. When the buttons are clicked return the action was done.

# How

- Added pressed functionality in Presseble passing default opacity 0.7
- Added `use_flipper` to fix error in build

# Sample

https://user-images.githubusercontent.com/44146877/162795924-016d7d3a-1904-4a0b-aa25-49d9c32e7686.mov


