### PR TITLE
Iconography: informations

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
     '!src/components/Icons/Dashboard/**/*.{ts,tsx}',
     '!src/components/Icons/Support/**/*.{ts,tsx}',
     '!src/components/Icons/Arrows/**/*.{ts,tsx}',
+    '!src/components/Icons/Information/**/*.{ts,tsx}',
     '!src/components/**/stories/**/*',
   ],
   coverageReporters: ['lcov', 'text', 'text-summary'],

--- a/src/components/Icons/Arrows/ArrowChevronDoubleDown.tsx
+++ b/src/components/Icons/Arrows/ArrowChevronDoubleDown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowChevronDoubleLeft.tsx
+++ b/src/components/Icons/Arrows/ArrowChevronDoubleLeft.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowChevronDoubleRight.tsx
+++ b/src/components/Icons/Arrows/ArrowChevronDoubleRight.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowChevronDoubleUp.tsx
+++ b/src/components/Icons/Arrows/ArrowChevronDoubleUp.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowChevronDown.tsx
+++ b/src/components/Icons/Arrows/ArrowChevronDown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowChevronLeft.tsx
+++ b/src/components/Icons/Arrows/ArrowChevronLeft.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowChevronRight.tsx
+++ b/src/components/Icons/Arrows/ArrowChevronRight.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowChevronUp.tsx
+++ b/src/components/Icons/Arrows/ArrowChevronUp.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowDown.tsx
+++ b/src/components/Icons/Arrows/ArrowDown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowDownCircle.tsx
+++ b/src/components/Icons/Arrows/ArrowDownCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowEnter.tsx
+++ b/src/components/Icons/Arrows/ArrowEnter.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowLeft.tsx
+++ b/src/components/Icons/Arrows/ArrowLeft.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowLeftCircle.tsx
+++ b/src/components/Icons/Arrows/ArrowLeftCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowLeftDown.tsx
+++ b/src/components/Icons/Arrows/ArrowLeftDown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowLeftUp.tsx
+++ b/src/components/Icons/Arrows/ArrowLeftUp.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowRefresh.tsx
+++ b/src/components/Icons/Arrows/ArrowRefresh.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowRight.tsx
+++ b/src/components/Icons/Arrows/ArrowRight.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowRightCircle.tsx
+++ b/src/components/Icons/Arrows/ArrowRightCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowRightDown.tsx
+++ b/src/components/Icons/Arrows/ArrowRightDown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowRightUp.tsx
+++ b/src/components/Icons/Arrows/ArrowRightUp.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowSort.tsx
+++ b/src/components/Icons/Arrows/ArrowSort.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowSwitch.tsx
+++ b/src/components/Icons/Arrows/ArrowSwitch.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowUndo.tsx
+++ b/src/components/Icons/Arrows/ArrowUndo.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowUp.tsx
+++ b/src/components/Icons/Arrows/ArrowUp.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Arrows/ArrowUpCircle.tsx
+++ b/src/components/Icons/Arrows/ArrowUpCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoAddCircle.tsx
+++ b/src/components/Icons/Information/InfoAddCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoAddCircle.tsx
+++ b/src/components/Icons/Information/InfoAddCircle.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoAddCircle({
+  id = 'InfoAddCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M12.8887 4C8.47039 4 4.88867 7.58172 4.88867 12C4.88867 16.4183 8.47039 20 12.8887 20C17.3069 20 20.8887 16.4183 20.8887 12C20.8887 7.58172 17.3069 4 12.8887 4ZM2.88867 12C2.88867 6.47715 7.36582 2 12.8887 2C18.4115 2 22.8887 6.47715 22.8887 12C22.8887 17.5228 18.4115 22 12.8887 22C7.36582 22 2.88867 17.5228 2.88867 12ZM12.8887 7C13.441 7 13.8887 7.44772 13.8887 8V11H16.8887C17.441 11 17.8887 11.4477 17.8887 12C17.8887 12.5523 17.441 13 16.8887 13H13.8887V16C13.8887 16.5523 13.441 17 12.8887 17C12.3364 17 11.8887 16.5523 11.8887 16V13H8.88867C8.33639 13 7.88867 12.5523 7.88867 12C7.88867 11.4477 8.33639 11 8.88867 11H11.8887V8C11.8887 7.44772 12.3364 7 12.8887 7Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoAddCircle;

--- a/src/components/Icons/Information/InfoBanCircle.tsx
+++ b/src/components/Icons/Information/InfoBanCircle.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoBanCircle({
+  id = 'InfoBanCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M6.56881 7.09436C5.51575 8.44904 4.88867 10.1513 4.88867 12C4.88867 16.4183 8.47039 20 12.8887 20C14.7374 20 16.4396 19.3729 17.7943 18.3199L6.56881 7.09436ZM7.98303 5.68014L19.2085 16.9056C20.2616 15.551 20.8887 13.8487 20.8887 12C20.8887 7.58172 17.3069 4 12.8887 4C11.04 4 9.33771 4.62708 7.98303 5.68014ZM2.88867 12C2.88867 6.47715 7.36582 2 12.8887 2C18.4115 2 22.8887 6.47715 22.8887 12C22.8887 17.5228 18.4115 22 12.8887 22C7.36582 22 2.88867 17.5228 2.88867 12Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoBanCircle;

--- a/src/components/Icons/Information/InfoBanCircle.tsx
+++ b/src/components/Icons/Information/InfoBanCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoCheckCircle.tsx
+++ b/src/components/Icons/Information/InfoCheckCircle.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoCheckCircle({
+  id = 'InfoCheckCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M12.8887 4C8.47039 4 4.88867 7.58172 4.88867 12C4.88867 16.4183 8.47039 20 12.8887 20C17.3069 20 20.8887 16.4183 20.8887 12C20.8887 7.58172 17.3069 4 12.8887 4ZM2.88867 12C2.88867 6.47715 7.36582 2 12.8887 2C18.4115 2 22.8887 6.47715 22.8887 12C22.8887 17.5228 18.4115 22 12.8887 22C7.36582 22 2.88867 17.5228 2.88867 12ZM17.553 8.75259C17.9658 9.11951 18.003 9.75158 17.6361 10.1644L12.3027 16.1644C12.113 16.3779 11.841 16.5 11.5553 16.5C11.2697 16.5 10.9977 16.3779 10.8079 16.1644L8.14126 13.1644C7.77434 12.7516 7.81153 12.1195 8.22431 11.7526C8.63709 11.3857 9.26916 11.4229 9.63608 11.8356L11.5553 13.9948L16.1413 8.83564C16.5082 8.42285 17.1403 8.38567 17.553 8.75259Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoCheckCircle;

--- a/src/components/Icons/Information/InfoCheckCircle.tsx
+++ b/src/components/Icons/Information/InfoCheckCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoErrorCircle.tsx
+++ b/src/components/Icons/Information/InfoErrorCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoErrorCircle.tsx
+++ b/src/components/Icons/Information/InfoErrorCircle.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoErrorCircle({
+  id = 'InfoErrorCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M12.8887 4C8.47039 4 4.88867 7.58172 4.88867 12C4.88867 16.4183 8.47039 20 12.8887 20C17.3069 20 20.8887 16.4183 20.8887 12C20.8887 7.58172 17.3069 4 12.8887 4ZM2.88867 12C2.88867 6.47715 7.36582 2 12.8887 2C18.4115 2 22.8887 6.47715 22.8887 12C22.8887 17.5228 18.4115 22 12.8887 22C7.36582 22 2.88867 17.5228 2.88867 12ZM8.68157 7.79289C9.07209 7.40237 9.70525 7.40237 10.0958 7.79289L12.8887 10.5858L15.6816 7.79289C16.0721 7.40237 16.7053 7.40237 17.0958 7.79289C17.4863 8.18342 17.4863 8.81658 17.0958 9.20711L14.3029 12L17.0958 14.7929C17.4863 15.1834 17.4863 15.8166 17.0958 16.2071C16.7053 16.5976 16.0721 16.5976 15.6816 16.2071L12.8887 13.4142L10.0958 16.2071C9.70525 16.5976 9.07209 16.5976 8.68157 16.2071C8.29104 15.8166 8.29104 15.1834 8.68157 14.7929L11.4745 12L8.68157 9.20711C8.29104 8.81658 8.29104 8.18342 8.68157 7.79289Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoErrorCircle;

--- a/src/components/Icons/Information/InfoHelpCicle.tsx
+++ b/src/components/Icons/Information/InfoHelpCicle.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoErrorCircle({
+  id = 'InfoErrorCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M12.8887 4C8.47039 4 4.88867 7.58172 4.88867 12C4.88867 16.4183 8.47039 20 12.8887 20C17.307 20 20.8887 16.4183 20.8887 12C20.8887 7.58172 17.307 4 12.8887 4ZM2.88867 12C2.88867 6.47715 7.36582 2 12.8887 2C18.4115 2 22.8887 6.47715 22.8887 12C22.8887 17.5228 18.4115 22 12.8887 22C7.36582 22 2.88867 17.5228 2.88867 12Z"
+        fill={fill}
+      />
+      <Path
+        d="M12.8887 14C12.3364 14 11.8887 13.5523 11.8887 13V12C11.8887 11.4477 12.3364 11 12.8887 11C13.441 11 13.8887 11.4477 13.8887 12V13C13.8887 13.5523 13.441 14 12.8887 14Z"
+        fill={fill}
+      />
+      <Path
+        d="M11.3887 16.5C11.3887 15.6716 12.0602 15 12.8887 15C13.7171 15 14.3887 15.6716 14.3887 16.5C14.3887 17.3284 13.7171 18 12.8887 18C12.0602 18 11.3887 17.3284 11.3887 16.5Z"
+        fill={fill}
+      />
+      <Path
+        d="M13.2786 7.81137C12.3216 7.7658 11.5191 8.3004 11.3751 9.1644C11.2843 9.70917 10.769 10.0772 10.2243 9.9864C9.6795 9.8956 9.31148 9.38037 9.40228 8.8356C9.75828 6.69961 11.7058 5.73421 13.3737 5.81363C14.2281 5.85432 15.1062 6.16099 15.7824 6.79278C16.4753 7.44027 16.8887 8.36777 16.8887 9.5C16.8887 10.7913 16.3806 11.7489 15.5059 12.3321C14.7027 12.8675 13.7182 13 12.8887 13C12.3364 13 11.8887 12.5523 11.8887 12C11.8887 11.4477 12.3364 11 12.8887 11C13.5591 11 14.0746 10.8825 14.3965 10.668C14.6468 10.5011 14.8887 10.2087 14.8887 9.5C14.8887 8.88224 14.6771 8.49723 14.4169 8.2541C14.1399 7.99526 13.7367 7.83318 13.2786 7.81137Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoErrorCircle;

--- a/src/components/Icons/Information/InfoHelpCicle.tsx
+++ b/src/components/Icons/Information/InfoHelpCicle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoInformationCicle.tsx
+++ b/src/components/Icons/Information/InfoInformationCicle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoInformationCicle.tsx
+++ b/src/components/Icons/Information/InfoInformationCicle.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoInformationCircle({
+  id = 'InfoInformationCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M12.8887 4C8.47039 4 4.88867 7.58172 4.88867 12C4.88867 16.4183 8.47039 20 12.8887 20C17.307 20 20.8887 16.4183 20.8887 12C20.8887 7.58172 17.307 4 12.8887 4ZM2.88867 12C2.88867 6.47715 7.36582 2 12.8887 2C18.4115 2 22.8887 6.47715 22.8887 12C22.8887 17.5228 18.4115 22 12.8887 22C7.36582 22 2.88867 17.5228 2.88867 12Z"
+        fill={fill}
+      />
+      <Path
+        d="M12.8887 10C13.441 10 13.8887 10.4477 13.8887 11V17C13.8887 17.5523 13.441 18 12.8887 18C12.3364 18 11.8887 17.5523 11.8887 17V11C11.8887 10.4477 12.3364 10 12.8887 10Z"
+        fill={fill}
+      />
+      <Path
+        d="M14.3887 7.5C14.3887 8.32843 13.7171 9 12.8887 9C12.0602 9 11.3887 8.32843 11.3887 7.5C11.3887 6.67157 12.0602 6 12.8887 6C13.7171 6 14.3887 6.67157 14.3887 7.5Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoInformationCircle;

--- a/src/components/Icons/Information/InfoRemoveCircle.tsx
+++ b/src/components/Icons/Information/InfoRemoveCircle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoRemoveCircle.tsx
+++ b/src/components/Icons/Information/InfoRemoveCircle.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoRemoveCircle({
+  id = 'InfoRemoveCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M12.8887 4C8.47039 4 4.88867 7.58172 4.88867 12C4.88867 16.4183 8.47039 20 12.8887 20C17.3069 20 20.8887 16.4183 20.8887 12C20.8887 7.58172 17.3069 4 12.8887 4ZM2.88867 12C2.88867 6.47715 7.36582 2 12.8887 2C18.4115 2 22.8887 6.47715 22.8887 12C22.8887 17.5228 18.4115 22 12.8887 22C7.36582 22 2.88867 17.5228 2.88867 12ZM7.88867 12C7.88867 11.4477 8.33639 11 8.88867 11H16.8887C17.441 11 17.8887 11.4477 17.8887 12C17.8887 12.5523 17.441 13 16.8887 13H8.88867C8.33639 13 7.88867 12.5523 7.88867 12Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoRemoveCircle;

--- a/src/components/Icons/Information/InfoWarning.tsx
+++ b/src/components/Icons/Information/InfoWarning.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoBanCircle({
+  id = 'InfoBanCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M12.8884 14C12.3361 14 11.8884 13.5523 11.8884 13V10C11.8884 9.44772 12.3361 9 12.8884 9C13.4406 9 13.8884 9.44772 13.8884 10V13C13.8884 13.5523 13.4406 14 12.8884 14Z"
+        fill={fill}
+      />
+      <Path
+        d="M11.3884 16.5C11.3884 15.6716 12.0599 15 12.8884 15C13.7168 15 14.3884 15.6716 14.3884 16.5C14.3884 17.3284 13.7168 18 12.8884 18C12.0599 18 11.3884 17.3284 11.3884 16.5Z"
+        fill={fill}
+      />
+      <Path
+        d="M11.1185 3.2156C11.8683 1.79093 13.9084 1.79092 14.6582 3.2156L23.0018 19.0685C23.7028 20.4003 22.737 22 21.232 22H4.54472C3.0397 22 2.07392 20.4003 2.77488 19.0685L11.1185 3.2156ZM21.232 20L12.8884 4.1471L4.54472 20L21.232 20Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoBanCircle;

--- a/src/components/Icons/Information/InfoWarning.tsx
+++ b/src/components/Icons/Information/InfoWarning.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/InfoWarningCicle.tsx
+++ b/src/components/Icons/Information/InfoWarningCicle.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { colors } from '@magnetis/astro-galaxy-tokens';
+import BaseIcon from '../BaseIcon';
+import { getFill, getSize, getViewBox } from '../utils';
+import type { IconProps } from '../types';
+
+function InfoWarningCircle({
+  id = 'InfoWarningCircleIcon',
+  color = colors.space100,
+  viewBox = getViewBox(),
+  width = getSize(),
+  height = getSize(),
+  ...props
+}: IconProps) {
+  const fill = React.useMemo(() => getFill({ gradient: props.gradient, color, id }), [color, props.gradient, id]);
+
+  return (
+    <BaseIcon id={id} color={color} width={width} height={height} viewBox={viewBox} {...props}>
+      <Path
+        d="M12.8887 4C8.47039 4 4.88867 7.58172 4.88867 12C4.88867 16.4183 8.47039 20 12.8887 20C17.307 20 20.8887 16.4183 20.8887 12C20.8887 7.58172 17.307 4 12.8887 4ZM2.88867 12C2.88867 6.47715 7.36582 2 12.8887 2C18.4115 2 22.8887 6.47715 22.8887 12C22.8887 17.5228 18.4115 22 12.8887 22C7.36582 22 2.88867 17.5228 2.88867 12Z"
+        fill={fill}
+      />
+      <Path
+        d="M12.8887 14C12.3364 14 11.8887 13.5523 11.8887 13L11.8887 7C11.8887 6.44772 12.3364 6 12.8887 6C13.441 6 13.8887 6.44772 13.8887 7L13.8887 13C13.8887 13.5523 13.441 14 12.8887 14Z"
+        fill={fill}
+      />
+      <Path
+        d="M11.3887 16.5C11.3887 15.6716 12.0602 15 12.8887 15C13.7171 15 14.3887 15.6716 14.3887 16.5C14.3887 17.3284 13.7171 18 12.8887 18C12.0602 18 11.3887 17.3284 11.3887 16.5Z"
+        fill={fill}
+      />
+    </BaseIcon>
+  );
+}
+
+export default InfoWarningCircle;

--- a/src/components/Icons/Information/InfoWarningCicle.tsx
+++ b/src/components/Icons/Information/InfoWarningCicle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Path } from 'react-native-svg';
 import { colors } from '@magnetis/astro-galaxy-tokens';
+
 import BaseIcon from '../BaseIcon';
 import { getFill, getSize, getViewBox } from '../utils';
 import type { IconProps } from '../types';

--- a/src/components/Icons/Information/index.ts
+++ b/src/components/Icons/Information/index.ts
@@ -1,0 +1,9 @@
+export { default as InfoAddCircleIcon } from './InfoAddCircle';
+export { default as InfoBanCircleIcon } from './InfoBanCircle';
+export { default as InfoCheckCircleIcon } from './InfoCheckCircle';
+export { default as InfoErrorCircleIcon } from './InfoErrorCircle';
+export { default as InfoHelpCicleIcon } from './InfoHelpCicle';
+export { default as InfoInformationCicleIcon } from './InfoInformationCicle';
+export { default as InfoRemoveCircleIcon } from './InfoRemoveCircle';
+export { default as InfoWarningIcon } from './InfoWarning';
+export { default as InfoWarningCicleIcon } from './InfoWarningCicle';

--- a/src/components/Icons/index.ts
+++ b/src/components/Icons/index.ts
@@ -1,5 +1,7 @@
 export * from './Dashboard';
 export * from './Support';
+// Temporarily commented out to avoid conflict with the existing icon with the same name. Already have a prioritized task to delete legacy icons
 // export * from './Arrows';
+// export * from './Information';
 
 export type { IconProps, IconID } from './types';


### PR DESCRIPTION
# What

Implement the new icons proposed in the [Iconography](https://www.figma.com/file/9WVVk8Vobz2ZMzmHjtEFEh/Iconography?node-id=1825%3A1490) spec

# Why

Enable us to have a greater visual collection, once we have a greater and more diverse amount of icons

# How

Added informations components in /components/Icons

# Sample

https://user-images.githubusercontent.com/44146877/166316580-a0846809-8c9d-49cb-bf6b-f39750e78a4a.mov

# QA
