### PR TITLE
chore(dependabot): update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,4 @@ updates:
       separator: '-'
     open-pull-requests-limit: 10
     reviewers:
-      - LopesAlysson
-      - pedro-cerdera
-      - lucianomlima
-      - albertozaranza
-      - Michele-Camargo
-      - RaissaMagnetis
-      - devjonathansouzasi
+      - 'magnetis/frontend'


### PR DESCRIPTION
# What

Set frontend team to dependabot reviewers. [Documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers)