### PR TITLE
feat(ButtonsGroup): update ButtonsGroup to receive props active inactive as default props [CONFIA-678]

### DIFF
--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -24,6 +24,7 @@ function Button({
   text,
   variant = 'primary',
   type = 'solid',
+  testID = 'Button',
   ...props
 }: ButtonProps) {
   const { backgroundColor, textColor } = getButtonProperties(disabled ? 'disabled' : variant, type);
@@ -45,10 +46,10 @@ function Button({
   const IconRight = getIcon(iconRight!);
 
   return (
-    <BaseButton {...props} {...baseProps} testID="Button">
+    <BaseButton {...props} {...baseProps} testID={testID}>
       <View style={{ alignItems: 'center', flexDirection: 'row' }}>
         {iconLeft && (
-          <View testID="Button.IconLeftContainer" style={{ marginRight: iconMargin }}>
+          <View testID={`${testID}.IconLeftContainer`} style={{ marginRight: iconMargin }}>
             <IconLeft size={iconSize} color={textColor} />
           </View>
         )}
@@ -56,7 +57,7 @@ function Button({
           {text}
         </BaseButtonText>
         {iconRight && (
-          <View testID="Button.IconRightContainer" style={{ marginLeft: iconMargin }}>
+          <View testID={`${testID}.IconRightContainer`} style={{ marginLeft: iconMargin }}>
             <IconRight size={iconSize} color={textColor} />
           </View>
         )}

--- a/src/components/ButtonsGroup/ButtonsGroup.tsx
+++ b/src/components/ButtonsGroup/ButtonsGroup.tsx
@@ -5,7 +5,7 @@ import { sizes } from '@magnetis/astro-tokens';
 import Button from '@components/Buttons/Button';
 
 import type { ViewStyle, PressableProps } from 'react-native';
-import type { ButtonVariant } from '@components/Buttons/types';
+import type { ButtonType, ButtonVariant } from '@components/Buttons/types';
 
 export type Item = PressableProps & {
   value: string;
@@ -16,29 +16,28 @@ export type ButtonsGroupProps = {
   testID?: string;
   contentContainerStyle?: ViewStyle;
   initialActiveItemIndex?: number;
-  inversed?: boolean;
   items: Item[];
-  legacy?: boolean;
   rounded?: boolean;
+  active?: {
+    type: ButtonType;
+    variant: ButtonVariant;
+  };
+  inactive?: {
+    type: ButtonType;
+    variant: ButtonVariant;
+  };
 };
 
 function ButtonsGroup({
   contentContainerStyle = {},
   initialActiveItemIndex = 0,
-  inversed,
   items,
-  legacy,
   rounded,
-  testID,
+  testID = 'ButtonsGroup',
+  active = { type: 'solid', variant: 'primary' },
+  inactive = { type: 'subtle', variant: 'inversed' },
 }: ButtonsGroupProps) {
   const [activeItem, setActiveItem] = useState(initialActiveItemIndex);
-
-  function getButtonGroupVariant(index: number): ButtonVariant {
-    if (activeItem === index && legacy) return 'legacy';
-    if (activeItem === index && !legacy) return 'primary';
-    if (inversed) return 'inversed';
-    return 'secondary';
-  }
 
   return (
     <FlatList
@@ -53,11 +52,12 @@ function ButtonsGroup({
       renderItem={({ item, index }) => (
         <Button
           {...item}
+          testID={`${testID}.Button.${index}`}
           size="small"
-          type={activeItem === index ? 'solid' : 'subtle'}
-          variant={getButtonGroupVariant(index)}
+          type={activeItem === index ? active.type : inactive.type}
+          variant={activeItem === index ? active.variant : inactive.variant}
           text={item.value}
-          rounded={legacy || rounded}
+          rounded={rounded}
           onPress={() => {
             setActiveItem(index);
             item.onPress();

--- a/src/components/ButtonsGroup/__tests__/ButtonsGroup.test.tsx
+++ b/src/components/ButtonsGroup/__tests__/ButtonsGroup.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import { colors, radius } from '@magnetis/astro-tokens';
-import { colors as legacyColors } from '@magnetis/astro-galaxy-tokens';
 
 import ButtonsGroup from '../ButtonsGroup';
 
@@ -15,8 +14,9 @@ const ITEMS: Item[] = [
 
 const initialProps: ButtonsGroupProps = {
   items: ITEMS,
-  inversed: false,
   testID: 'ButtonsGroup',
+  active: { type: 'solid', variant: 'primary' },
+  inactive: { type: 'subtle', variant: 'inversed' },
 };
 
 describe('ButtonsGroup', () => {
@@ -27,66 +27,39 @@ describe('ButtonsGroup', () => {
   });
 
   it('should renders correctly with default props', () => {
-    const { getByTestId, getAllByTestId } = render(<ButtonsGroup {...initialProps} />);
+    const { getByTestId } = render(<ButtonsGroup {...initialProps} />);
 
     expect(getByTestId('ButtonsGroup')).toHaveProp('contentContainerStyle', { flexGrow: 1, justifyContent: 'center' });
 
-    expect(getAllByTestId('Button')[0]).toHaveStyle({
+    expect(getByTestId('ButtonsGroup.Button.0')).toHaveStyle({
       backgroundColor: colors.solidPrimaryMedium,
       borderRadius: radius.small,
     });
 
-    expect(getAllByTestId('Button')[1]).toHaveStyle({
-      backgroundColor: colors.transparentFaintSemitransparent,
-      borderRadius: radius.small,
-    });
-  });
-
-  it('should renders correctly with inversed prop', () => {
-    const { getByTestId, getAllByTestId } = render(<ButtonsGroup {...initialProps} inversed />);
-
-    expect(getByTestId('ButtonsGroup')).toHaveProp('contentContainerStyle', { flexGrow: 1, justifyContent: 'center' });
-
-    expect(getAllByTestId('Button')[1]).toHaveStyle({
+    expect(getByTestId('ButtonsGroup.Button.1')).toHaveStyle({
       backgroundColor: colors.transparentBrightSemitransparent,
       borderRadius: radius.small,
     });
   });
 
   it('should renders correctly with rounded prop', () => {
-    const { getByTestId, getAllByTestId } = render(<ButtonsGroup {...initialProps} rounded />);
+    const { getByTestId } = render(<ButtonsGroup {...initialProps} rounded />);
 
     expect(getByTestId('ButtonsGroup').props.contentContainerStyle).toEqual({ flexGrow: 1, justifyContent: 'center' });
 
-    expect(getAllByTestId('Button')[0]).toHaveStyle({
+    expect(getByTestId('ButtonsGroup.Button.0')).toHaveStyle({
       backgroundColor: colors.solidPrimaryMedium,
       borderRadius: radius.circular,
     });
 
-    expect(getAllByTestId('Button')[1]).toHaveStyle({
-      backgroundColor: colors.transparentFaintSemitransparent,
-      borderRadius: radius.circular,
-    });
-  });
-
-  it('should renders correctly with legacy prop', () => {
-    const { getByTestId, getAllByTestId } = render(<ButtonsGroup {...initialProps} legacy rounded />);
-
-    expect(getByTestId('ButtonsGroup')).toHaveProp('contentContainerStyle', { flexGrow: 1, justifyContent: 'center' });
-
-    expect(getAllByTestId('Button')[0]).toHaveStyle({
-      backgroundColor: legacyColors.uranus500,
-      borderRadius: radius.circular,
-    });
-
-    expect(getAllByTestId('Button')[1]).toHaveStyle({
-      backgroundColor: colors.transparentFaintSemitransparent,
+    expect(getByTestId('ButtonsGroup.Button.1')).toHaveStyle({
+      backgroundColor: colors.transparentBrightSemitransparent,
       borderRadius: radius.circular,
     });
   });
 
   it('should renders correctly with contentContainerStyle prop', () => {
-    const { getByTestId, getAllByTestId } = render(
+    const { getByTestId } = render(
       <ButtonsGroup {...initialProps} contentContainerStyle={{ justifyContent: 'space-between' }} />
     );
 
@@ -95,13 +68,13 @@ describe('ButtonsGroup', () => {
       justifyContent: 'space-between',
     });
 
-    expect(getAllByTestId('Button')[0]).toHaveStyle({
+    expect(getByTestId('ButtonsGroup.Button.0')).toHaveStyle({
       backgroundColor: colors.solidPrimaryMedium,
       borderRadius: radius.small,
     });
 
-    expect(getAllByTestId('Button')[1]).toHaveStyle({
-      backgroundColor: colors.transparentFaintSemitransparent,
+    expect(getByTestId('ButtonsGroup.Button.1')).toHaveStyle({
+      backgroundColor: colors.transparentBrightSemitransparent,
       borderRadius: radius.small,
     });
   });
@@ -118,5 +91,29 @@ describe('ButtonsGroup', () => {
     const { getByA11yLabel } = render(<ButtonsGroup {...initialProps} />);
 
     expect(getByA11yLabel(accessibilityLabel)).toBeTruthy();
+  });
+
+  it('renders correctly changing active and inactive default values', () => {
+    const { getByTestId } = render(
+      <ButtonsGroup
+        {...initialProps}
+        contentContainerStyle={{ justifyContent: 'space-between' }}
+        active={{ type: 'subtle', variant: 'inversed' }}
+        inactive={{ type: 'solid', variant: 'primary' }}
+      />
+    );
+
+    expect(getByTestId('ButtonsGroup')).toHaveProp('contentContainerStyle', {
+      flexGrow: 1,
+      justifyContent: 'space-between',
+    });
+
+    expect(getByTestId('ButtonsGroup.Button.0')).toHaveStyle({
+      backgroundColor: colors.transparentBrightSemitransparent,
+    });
+
+    expect(getByTestId('ButtonsGroup.Button.1')).toHaveStyle({
+      backgroundColor: colors.solidPrimaryMedium,
+    });
   });
 });

--- a/src/components/ButtonsGroup/stories/ButtonsGroup.story.tsx
+++ b/src/components/ButtonsGroup/stories/ButtonsGroup.story.tsx
@@ -7,6 +7,7 @@ import { colors, sizes } from '@magnetis/astro-tokens';
 import ButtonsGroup from '../ButtonsGroup';
 
 import type { Item } from '../ButtonsGroup';
+import { buttonTypeOptions, buttonVariantOptions } from '@components/Buttons/types';
 
 const ITEMS: Item[] = [
   { value: 'lorem', onPress: () => console.log('lorem') },
@@ -22,10 +23,16 @@ storiesOf('Buttons Group', module).add('Buttons Group', () => (
       <ButtonsGroup
         contentContainerStyle={object('contentContainerStyle', {})}
         initialActiveItemIndex={select('initialActiveItemIndex', ITEMS_INDEX, ITEMS_INDEX[0])}
-        inversed={boolean('inversed', true)}
         items={ITEMS}
-        legacy={boolean('legacy', true)}
         rounded={boolean('rounded', false)}
+        active={{
+          type: select('ActiveType', buttonTypeOptions, buttonTypeOptions[0]),
+          variant: select('ActiveVariant', buttonVariantOptions, buttonVariantOptions[0]),
+        }}
+        inactive={{
+          type: select('InactiveType', buttonTypeOptions, buttonTypeOptions[1]),
+          variant: select('InactiveVariant', buttonVariantOptions, buttonVariantOptions[4]),
+        }}
       />
     </View>
     <View style={{ marginTop: sizes.mini }}>
@@ -33,8 +40,15 @@ storiesOf('Buttons Group', module).add('Buttons Group', () => (
         contentContainerStyle={object('contentContainerStyle', {})}
         initialActiveItemIndex={select('initialActiveItemIndex', ITEMS_INDEX, ITEMS_INDEX[0])}
         items={ITEMS}
-        legacy={boolean('legacy', false)}
         rounded={boolean('rounded', false)}
+        active={{
+          type: select('ActiveType', buttonTypeOptions, buttonTypeOptions[0]),
+          variant: select('ActiveVariant', buttonVariantOptions, buttonVariantOptions[0]),
+        }}
+        inactive={{
+          type: select('InactiveType', buttonTypeOptions, buttonTypeOptions[1]),
+          variant: select('InactiveVariant', buttonVariantOptions, buttonVariantOptions[4]),
+        }}
       />
     </View>
   </SafeAreaView>


### PR DESCRIPTION
# What

Updates ButtonsGroup to receive props `active` and `inactive` as default props.

# Why

Following the needs to optimize our components.

# How

- Add `active` and `inactive` props to ButtonGroups to load by default:
- Deprecate `inverted` and `legacy` props;
- Correct the `ButtonGroupProps` types;
- Delete function `getButtonGroupVariant`;
- Use `type` and `variant` properties according to whether the button is active or not;
- Fix unit tests;

# Sample

<!-- Add screenshots or gifs when relevant -->

# QA

1. Start storybook with `yarn storybook`;
2. Run your preferred simulator;
4. In the storybook page, choose `Buttons Group` in `Buttons Group`;
5. See if `ActiveType`, `ActiveVariant`, `InactiveType` and `InactiveVariant` props are working correctly;

<!-- Add instructions for QA >

<!-- ✅ TODOs -->
<!-- Assign at least one manteiner to review this PR -->
<!-- Assign everyone who worked on this PR -->

<!-- EXTRAS -->
<!-- 💸 Describe possible tech debits -->
<!-- Jira link if needed -->
[CONFIA-678](https://produtomagnetis.atlassian.net/browse/CONFIA-678)


[CONFIA-678]: https://produtomagnetis.atlassian.net/browse/CONFIA-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ