### PR TITLE
release: bump version from v2.0.0-next.8 to v2.0.0-next.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [2.0.0-next.9](https://github.com/magnetis/astro-native/compare/v2.0.0-next.8...v2.0.0-next.9) (2023-02-27)
+
+
+### Bug Fixes
+
+* **fonts:** make fontWeight and fontStyle style props work for fonts ([#691](https://github.com/magnetis/astro-native/issues/691)) ([d722b87](https://github.com/magnetis/astro-native/commit/d722b87b8feff95df6391f198a16a385e903b985))
+* **svg:** fix svg path in icon components ([#685](https://github.com/magnetis/astro-native/issues/685)) ([376ed56](https://github.com/magnetis/astro-native/commit/376ed565d95937343348b3509007b31c621a37ee))
+
+
+### Features
+
+* **ButtounsGroup:** update ButtonsGroup component [CONFIA-816] ([#687](https://github.com/magnetis/astro-native/issues/687)) ([6b577f8](https://github.com/magnetis/astro-native/commit/6b577f8da44b62b957c702cc28f3e33ba113eb7b))
+
+
+
 # [2.0.0-next.8](https://github.com/magnetis/astro-native/compare/v2.0.0-next.7...v2.0.0-next.8) (2023-01-12)
 
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "build": "tsc --project tsconfig.prod.json && tscpaths -p tsconfig.prod.json -s ./src -o ./dist",
     "lint": "eslint ./src --ext .ts,.tsx",
     "storybook": "start-storybook -p 7007",
-    "version": "yarn clean && yarn build && standard-changelog && git add CHANGELOG.md package.json",
-    "prepare": "npx husky install"
+    "version": "standard-changelog && git add CHANGELOG.md package.json",
+    "prepare": "npx husky install",
+    "prepublishOnly": "yarn clean && yarn build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-native",
-  "version": "2.0.0-next.8",
+  "version": "2.0.0-next.9",
   "description": "Astro components for React Native",
   "homepage": "https://astro-galaxy.magnetis.com.br/",
   "files": [
@@ -18,11 +18,11 @@
     "test:watch": "TZ=UTC jest --watch --verbose --maxWorkers=25%",
     "test:coverage": "TZ=UTC jest --ci --coverage --runInBand",
     "clean": "rm -rf ./dist",
+    "build": "tsc --project tsconfig.prod.json && tscpaths -p tsconfig.prod.json -s ./src -o ./dist",
     "lint": "eslint ./src --ext .ts,.tsx",
     "storybook": "start-storybook -p 7007",
-    "version": "standard-changelog && git add CHANGELOG.md package.json && git commit -m \"release: bump version to v${npm_package_version}\"",
-    "prepare": "npx husky install",
-    "prepublishOnly": "yarn clean && tsc --project tsconfig.prod.json && tscpaths -p tsconfig.prod.json -s ./src -o ./dist"
+    "version": "yarn clean && yarn build && standard-changelog && git add CHANGELOG.md package.json",
+    "prepare": "npx husky install"
   },
   "repository": {
     "type": "git",
@@ -73,13 +73,13 @@
     "jest": "^26.6.3",
     "lint-staged": "^11.0.0",
     "metro-react-native-babel-preset": "^0.66.0",
-    "react-native-codegen": "^0.0.7",
     "mockdate": "^3.0.2",
     "prettier": "2.6.2",
     "react": "17.0.2",
     "react-native": "0.65.3",
-    "react-test-renderer": "17.0.2",
+    "react-native-codegen": "^0.0.7",
     "react-native-gesture-handler": "^2.9.0",
+    "react-test-renderer": "17.0.2",
     "standard-changelog": "^2.0.27",
     "ts-jest": "^26.5.6",
     "tscpaths": "^0.0.9",


### PR DESCRIPTION
# [2.0.0-next.9](https://github.com/magnetis/astro-native/compare/v2.0.0-next.8...v2.0.0-next.9) (2023-02-27)

## Bug Fixes

* **fonts:** make fontWeight and fontStyle style props work for fonts ([#691](https://github.com/magnetis/astro-native/issues/691)) ([d722b87](https://github.com/magnetis/astro-native/commit/d722b87b8feff95df6391f198a16a385e903b985))
* **svg:** fix svg path in icon components ([#685](https://github.com/magnetis/astro-native/issues/685)) ([376ed56](https://github.com/magnetis/astro-native/commit/376ed565d95937343348b3509007b31c621a37ee))

## Features

* **ButtounsGroup:** update ButtonsGroup component [CONFIA-816] ([#687](https://github.com/magnetis/astro-native/issues/687)) ([6b577f8](https://github.com/magnetis/astro-native/commit/6b577f8da44b62b957c702cc28f3e33ba113eb7b))

[CONFIA-836](https://produtomagnetis.atlassian.net/browse/CONFIA-836)

[CONFIA-816]: https://produtomagnetis.atlassian.net/browse/CONFIA-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CONFIA-836]: https://produtomagnetis.atlassian.net/browse/CONFIA-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ