### PR TITLE
feat(link): allow use any color

### DIFF
--- a/src/components/Buttons/Link.tsx
+++ b/src/components/Buttons/Link.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { TextProps } from 'react-native';
+import type { ColorValue } from 'react-native';
 
 import type { ButtonColor } from './types';
 import { getButtonMainColor, isValidTextComponent } from './utils';
@@ -7,7 +8,7 @@ import { getButtonMainColor, isValidTextComponent } from './utils';
 interface LinkProps extends TextProps {
   children: ReactElement;
   /** Color to be used as background color of button. Defaults to `"uranus"`. */
-  color?: ButtonColor;
+  color?: ColorValue;
   /** Link press callback */
   onPress: () => void;
 }
@@ -19,7 +20,7 @@ function Link({ children, onPress, color = 'uranus', ...props }: LinkProps) {
   return isValidTextComponent(children)
     ? React.cloneElement(children, {
         ...props,
-        color: getButtonMainColor(color),
+        color: getButtonMainColor(color as ButtonColor),
         onPress,
         style: { textDecorationLine: 'underline' },
       })

--- a/src/components/Buttons/__tests__/Link.test.tsx
+++ b/src/components/Buttons/__tests__/Link.test.tsx
@@ -43,6 +43,36 @@ describe('Link', () => {
     );
   });
 
+  it('renders correctly with string color prop', () => {
+    const { getByText } = render(
+      <Link onPress={onPress} color="yellow">
+        <PrimaryTextMedium>this is a link</PrimaryTextMedium>
+      </Link>
+    );
+
+    expect(getByText('this is a link').props.style).toEqual(
+      expect.objectContaining({
+        textDecorationLine: 'underline',
+        color: 'yellow',
+      })
+    );
+  });
+
+  it('renders correctly with hexadecimal color prop', () => {
+    const { getByText } = render(
+      <Link onPress={onPress} color="#30458C">
+        <PrimaryTextMedium>this is a link</PrimaryTextMedium>
+      </Link>
+    );
+
+    expect(getByText('this is a link').props.style).toEqual(
+      expect.objectContaining({
+        textDecorationLine: 'underline',
+        color: '#30458C',
+      })
+    );
+  });
+
   it('renders nothing when child is not valid', () => {
     const { queryByText } = render(
       <Link onPress={onPress}>

--- a/src/components/Buttons/stories/Link.story.tsx
+++ b/src/components/Buttons/stories/Link.story.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { select, text } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 
 import { PrimaryTextMedium } from '@components/Text';
-import { buttonColorOptions } from '@root/storybook/options';
 
 import { Link } from '..';
 
 storiesOf('Buttons', module).add('Link', () => (
-  <Link color={select('color', buttonColorOptions, 'uranus')} onPress={() => console.log('Pressed')}>
+  <Link color={text('color', 'uranus')} onPress={() => console.log('Pressed')}>
     <PrimaryTextMedium>{text('text', 'Button')}</PrimaryTextMedium>
   </Link>
 ));

--- a/src/components/Buttons/stories/Link.story.tsx
+++ b/src/components/Buttons/stories/Link.story.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
+import { select, text } from '@storybook/addon-knobs';
+
+import { PrimaryTextMedium } from '@components/Text';
+import { buttonColorOptions } from '@root/storybook/options';
 
 import { Link } from '..';
-import { PrimaryTextMedium } from '@components/Text';
 
 storiesOf('Buttons', module).add('Link', () => (
-  <Link onPress={() => console.log('Pressed')}>
-    <PrimaryTextMedium>Button</PrimaryTextMedium>
+  <Link color={select('color', buttonColorOptions, 'uranus')} onPress={() => console.log('Pressed')}>
+    <PrimaryTextMedium>{text('text', 'Button')}</PrimaryTextMedium>
   </Link>
 ));
 

--- a/src/components/Buttons/utils.ts
+++ b/src/components/Buttons/utils.ts
@@ -113,8 +113,10 @@ export function getButtonMainColor(
       return colors.moon600;
     case 'space':
       return colors.moon100;
-    default:
+    case 'uranus':
       return colors.uranus500;
+    default:
+      return color;
   }
 }
 


### PR DESCRIPTION
# What
Use any color in Link component.

# Why
To fix layout issues when using Link without new color tokens.

# How
- Changed getButtonMainColor function to return color if doesn't match legacy color tokens.

# Sample

https://github.com/magnetis/astro-native/assets/1580205/e01a8314-d2d2-472b-b7f0-21c4fc816201

# QA
- Run yarn start
- Run storybook
- Open Android and iOS simulators
- Choose Link component in storybook
- Try several color names and codes like `red`, `yellow`, `#306090` and other ones

[CONFIA-1202](https://produtomagnetis.atlassian.net/browse/CONFIA-1202)

[CONFIA-1202]: https://produtomagnetis.atlassian.net/browse/CONFIA-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ