### PR TITLE
chore: prepare for release v1.11.0

### DIFF
--- a/ios/AstroNative.xcodeproj/project.pbxproj
+++ b/ios/AstroNative.xcodeproj/project.pbxproj
@@ -58,21 +58,21 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = AstroNative/main.m; sourceTree = "<group>"; };
 		2D02E47B1E0B4A5D006451C7 /* AstroNative-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AstroNative-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* AstroNative-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AstroNative-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4748DE1888D04F759EC1E292 /* Poppins-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-SemiBold.ttf"; path = "../src/assets/fonts/Poppins-SemiBold.ttf"; sourceTree = "<group>"; };
+		4748DE1888D04F759EC1E292 /* Poppins-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-SemiBold.ttf"; path = "../src/assets/fonts/Poppins-SemiBold.ttf"; sourceTree = "<group>"; };
 		697F65C910C56DB3C12E8F19 /* Pods-AstroNative.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AstroNative.debug.xcconfig"; path = "Target Support Files/Pods-AstroNative/Pods-AstroNative.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = AstroNative/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		9BF9301B54AC4B66B2994826 /* Poppins-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-Bold.ttf"; path = "../src/assets/fonts/Poppins-Bold.ttf"; sourceTree = "<group>"; };
+		9BF9301B54AC4B66B2994826 /* Poppins-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-Bold.ttf"; path = "../src/assets/fonts/Poppins-Bold.ttf"; sourceTree = "<group>"; };
 		B890E7352914156D5926E0A9 /* Pods-AstroNative-AstroNativeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AstroNative-AstroNativeTests.release.xcconfig"; path = "Target Support Files/Pods-AstroNative-AstroNativeTests/Pods-AstroNative-AstroNativeTests.release.xcconfig"; sourceTree = "<group>"; };
 		BDA1A773E8EFAE9CAAA7CE3E /* Pods-AstroNative.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AstroNative.release.xcconfig"; path = "Target Support Files/Pods-AstroNative/Pods-AstroNative.release.xcconfig"; sourceTree = "<group>"; };
 		BF8BDD52CF67325B9D3B2C22 /* libPods-AstroNative-AstroNativeTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AstroNative-AstroNativeTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C528746832DE43D287E5C462 /* Lato-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Lato-Bold.ttf"; path = "../src/assets/fonts/Lato-Bold.ttf"; sourceTree = "<group>"; };
-		CCDF1644084E4DE1AB78AFDE /* Lato-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Lato-Regular.ttf"; path = "../src/assets/fonts/Lato-Regular.ttf"; sourceTree = "<group>"; };
-		DBD2279B8A56461282A1A3E4 /* Poppins-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-Black.ttf"; path = "../src/assets/fonts/Poppins-Black.ttf"; sourceTree = "<group>"; };
-		DE4499C3CA004EA0855B862B /* Poppins-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-Medium.ttf"; path = "../src/assets/fonts/Poppins-Medium.ttf"; sourceTree = "<group>"; };
+		C528746832DE43D287E5C462 /* Lato-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Lato-Bold.ttf"; path = "../src/assets/fonts/Lato-Bold.ttf"; sourceTree = "<group>"; };
+		CCDF1644084E4DE1AB78AFDE /* Lato-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Lato-Regular.ttf"; path = "../src/assets/fonts/Lato-Regular.ttf"; sourceTree = "<group>"; };
+		DBD2279B8A56461282A1A3E4 /* Poppins-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-Black.ttf"; path = "../src/assets/fonts/Poppins-Black.ttf"; sourceTree = "<group>"; };
+		DE4499C3CA004EA0855B862B /* Poppins-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-Medium.ttf"; path = "../src/assets/fonts/Poppins-Medium.ttf"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		EE0403B09D5799D886505091 /* Pods-AstroNative-AstroNativeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AstroNative-AstroNativeTests.debug.xcconfig"; path = "Target Support Files/Pods-AstroNative-AstroNativeTests/Pods-AstroNative-AstroNativeTests.debug.xcconfig"; sourceTree = "<group>"; };
-		F3C4A62910114538AF9548AB /* Poppins-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-Regular.ttf"; path = "../src/assets/fonts/Poppins-Regular.ttf"; sourceTree = "<group>"; };
+		F3C4A62910114538AF9548AB /* Poppins-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-Regular.ttf"; path = "../src/assets/fonts/Poppins-Regular.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,7 +148,6 @@
 				EE0403B09D5799D886505091 /* Pods-AstroNative-AstroNativeTests.debug.xcconfig */,
 				B890E7352914156D5926E0A9 /* Pods-AstroNative-AstroNativeTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -209,7 +208,6 @@
 				4748DE1888D04F759EC1E292 /* Poppins-SemiBold.ttf */,
 			);
 			name = Resources;
-			path = "";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -675,6 +673,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = AstroNative/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -697,6 +696,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = AstroNative/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -502,7 +502,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "test:watch": "TZ=UTC jest --watch --verbose --maxWorkers=25%",
     "test:coverage": "TZ=UTC jest --ci --coverage --runInBand",
     "clean": "rm -rf ./dist",
+    "build": "tsc --project tsconfig.prod.json && tscpaths -p tsconfig.prod.json -s ./src -o ./dist",
     "lint": "eslint ./src --ext .ts,.tsx",
     "storybook": "start-storybook -p 7007",
-    "version": "standard-changelog && git add CHANGELOG.md package.json && git commit -m \"release: bump version to v${npm_package_version}\"",
+    "version": "standard-changelog && git add CHANGELOG.md package.json",
     "prepare": "npx husky install",
-    "prepublishOnly": "yarn clean && tsc --project tsconfig.prod.json && tscpaths -p tsconfig.prod.json -s ./src -o ./dist"
+    "prepublishOnly": "yarn clean && yarn build"
   },
   "repository": {
     "type": "git",
@@ -33,10 +34,6 @@
     "design-system"
   ],
   "author": "Magnetis (https://github.com/magnetis)",
-  "maintainers": [
-    "Alysson Lopes <alyssondlopes@gmail.com>",
-    "Tobias Ulrich <tobiasbulrich@gmail.com"
-  ],
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "7.12.9",

--- a/src/components/Text/BaseText.tsx
+++ b/src/components/Text/BaseText.tsx
@@ -1,11 +1,11 @@
-import type { StyleProp, TextProps, TextStyle } from 'react-native';
 import React, { ReactNode } from 'react';
 import { Text } from 'react-native';
+import type { ColorValue, StyleProp, TextProps, TextStyle } from 'react-native';
 
 interface BaseTextProps extends TextProps {
-  color: string;
   align: 'auto' | 'left' | 'right' | 'center' | 'justify';
   children: ReactNode;
+  color: ColorValue;
   fontFamily: string;
   fontSize: number;
 }

--- a/src/components/Text/PrimaryText.tsx
+++ b/src/components/Text/PrimaryText.tsx
@@ -10,7 +10,7 @@ export interface PrimaryTextProps extends BaseTextProps {
   bold?: boolean;
 }
 
-function BasePrimatyText({
+function BasePrimaryText({
   semiBold = false,
   bold = false,
   color = colors.moon900,
@@ -40,9 +40,9 @@ function BasePrimatyText({
  */
 export function PrimaryTextVerySmall({ children, ...props }: PrimaryTextProps) {
   return (
-    <BasePrimatyText {...props} fontSize={12}>
+    <BasePrimaryText {...props} fontSize={12}>
       {children}
-    </BasePrimatyText>
+    </BasePrimaryText>
   );
 }
 
@@ -54,9 +54,9 @@ export function PrimaryTextVerySmall({ children, ...props }: PrimaryTextProps) {
  */
 export function PrimaryTextSmall({ children, ...props }: PrimaryTextProps) {
   return (
-    <BasePrimatyText {...props} fontSize={14}>
+    <BasePrimaryText {...props} fontSize={14}>
       {children}
-    </BasePrimatyText>
+    </BasePrimaryText>
   );
 }
 
@@ -68,9 +68,9 @@ export function PrimaryTextSmall({ children, ...props }: PrimaryTextProps) {
  */
 export function PrimaryTextMedium({ children, ...props }: PrimaryTextProps) {
   return (
-    <BasePrimatyText {...props} fontSize={16}>
+    <BasePrimaryText {...props} fontSize={16}>
       {children}
-    </BasePrimatyText>
+    </BasePrimaryText>
   );
 }
 
@@ -82,8 +82,8 @@ export function PrimaryTextMedium({ children, ...props }: PrimaryTextProps) {
  */
 export function PrimaryTextLarge({ children, ...props }: PrimaryTextProps) {
   return (
-    <BasePrimatyText {...props} fontSize={24}>
+    <BasePrimaryText {...props} fontSize={24}>
       {children}
-    </BasePrimatyText>
+    </BasePrimaryText>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5476,9 +5476,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001165, caniuse-lite@^1.0.30001254, caniuse-lite@^1.0.30001400:
-  version "1.0.30001439"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz"
-  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
+  version "1.0.30001506"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz"
+  integrity sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# What
Configure iOS to v11, remove outdated maintainers info, update browserslist database and fix typo in PrymaryText component internal name

# Why
To release version 1.11.0

# How
- Configure iOS to v11,
- Remove outdated maintainers info
- Update browserslist database
- Fix typo in PrymaryText component internal nbame

# QA
Checkout branch and run in different terminal panels:
- `yarn`
- `yarn start`
- `yarn storybook`
- `yarn android`
- `yarn ios` (now can be run in the same terminal without rosetta)