### PR TITLE
chore: bump node version from 14 to 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Use Checkout
         uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
       - name: Get release version
         uses: actions/github-script@v6

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Use Checkout
         uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
# What

Update node version from 14 to 16 on Github Actions Workflows.

# Why

To run Node from the default version, 16, and fix the following error:
`error cosmiconfig-typescript-loader@5.0.0: The engine "node" is incompatible with this module. Expected version ">=v16". Got "14.21.3"`

# How

Updating Node version on `.github/workflows/publish.yml`;
Updating Node version on `.github/workflows/pull-requests.yml`;

# Sample

<!-- Add screenshots or gifs when relevant -->

# QA

<!-- Add instructions for QA >

<!-- ✅ TODOs -->
<!-- Assign at least one manteiner to review this PR -->
<!-- Assign everyone who worked on this PR -->

<!-- EXTRAS -->
<!-- 💸 Describe possible tech debits -->
<!-- Jira link if needed -->
