### PR TITLE
chore(dev-deps): bump codecov version from 3.8.1 to 3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.1.0",
     "babel-plugin-module-resolver": "^4.0.0",
-    "codecov": "^3.8.1",
+    "codecov": "^3.8.3",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5769,7 +5769,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@^3.8.1:
+codecov@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.8.3.tgz#9c3e364b8a700c597346ae98418d09880a3fdbe7"
   integrity sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==


### PR DESCRIPTION
# What

Bump `codecov` version from 3.8.1 to 3.8.3.

# Why

To fix `TypeError: Cannot read property 'startsWith' of undefined` on Github Actions as suggested in https://github.com/codecov/codecov-node/issues/324 thread.

# How

Updating the version of `codecov` in `package.json` and `yarn.lock`

# Sample

<!-- Add screenshots or gifs when relevant -->

# QA

<!-- Add instructions for QA >

<!-- ✅ TODOs -->
<!-- Assign at least one manteiner to review this PR -->
<!-- Assign everyone who worked on this PR -->

<!-- EXTRAS -->
<!-- 💸 Describe possible tech debits -->
<!-- Jira link if needed -->
