### PR TITLE
chore: bump version to v2.0.0-next.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [2.0.0-next.12](https://github.com/magnetis/astro-native/compare/v2.0.0-next.11...v2.0.0-next.12) (2023-08-22)
+
+
+### Features
+
+* **components:** add divider component in astro-native-next [CONFIA-1337] ([#782](https://github.com/magnetis/astro-native/issues/782)) ([6baef63](https://github.com/magnetis/astro-native/commit/6baef6384699ee0d96fcbaf33ffe2bd1542f9ff1))
+* **components:** create tag component on astro-native@next [CONFIA-1335] ([#791](https://github.com/magnetis/astro-native/issues/791)) ([0f13a14](https://github.com/magnetis/astro-native/commit/0f13a14caf608c97084747e8ff71f4da7bf4738d))
+
+
+
 # [2.0.0-next.11](https://github.com/magnetis/astro-native/compare/v2.0.0-next.10...v2.0.0-next.11) (2023-07-31)
 
 ### Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-native",
-  "version": "2.0.0-next.11",
+  "version": "2.0.0-next.12",
   "description": "Astro components for React Native",
   "homepage": "https://astro-galaxy.magnetis.com.br/",
   "files": [


### PR DESCRIPTION
# [2.0.0-next.12](https://github.com/magnetis/astro-native/compare/v2.0.0-next.11...v2.0.0-next.12) (2023-08-22)


### Features

* **components:** add divider component in astro-native-next [CONFIA-1337] ([#782](https://github.com/magnetis/astro-native/issues/782)) ([6baef63](https://github.com/magnetis/astro-native/commit/6baef6384699ee0d96fcbaf33ffe2bd1542f9ff1))
* **components:** create tag component on astro-native@next [CONFIA-1335] ([#791](https://github.com/magnetis/astro-native/issues/791)) ([0f13a14](https://github.com/magnetis/astro-native/commit/0f13a14caf608c97084747e8ff71f4da7bf4738d))

<!-- ✅ TODOs -->
<!-- Assign at least one manteiner to review this PR -->
<!-- Assign everyone who worked on this PR -->

<!-- EXTRAS -->
<!-- 💸 Describe possible tech debits -->
<!-- Jira link if needed -->


[CONFIA-1337]: https://produtomagnetis.atlassian.net/browse/CONFIA-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CONFIA-1335]: https://produtomagnetis.atlassian.net/browse/CONFIA-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ