### PR TITLE
fix: Node 20 compatibility in next branch [CONFIA-1419]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "scripts": {
     "android": "react-native run-android && adb reverse tcp:7007 tcp:7007",
     "ios": "react-native run-ios",
-    "start": "yarn react-native start",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-native start",
     "test": "TZ=UTC jest --maxWorkers=50%",
     "test:watch": "TZ=UTC jest --watch --verbose --maxWorkers=25%",
     "test:coverage": "TZ=UTC jest --ci --coverage --runInBand",
     "clean": "rm -rf ./dist",
     "build": "tsc --project tsconfig.prod.json && tscpaths -p tsconfig.prod.json -s ./src -o ./dist",
     "lint": "eslint ./src --ext .ts,.tsx",
-    "storybook": "start-storybook -p 7007",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 7007",
     "version": "standard-changelog && git add CHANGELOG.md package.json",
     "prepare": "npx husky install",
     "prepublishOnly": "yarn clean && yarn build"


### PR DESCRIPTION
# What
Makes project compatilbe with NodeJS 20

# Why
Current NodeJS version that we use has reached end of life, what means that it will not receive updates and fixes anymore.
So, we move to NodeJS 20 and fix the project to works with it.

# How
Set openssl-legacy-provider node option env var in start and storybook commands.

# QA

1. Checkout the branch, remove `node_modules` folder and install dependencies with `yarn`
2. Start packager with `yarn start`
3. Start storybook with `yarn storybook`
4. Run app in both platforms (Android and iOS)